### PR TITLE
Katapult rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,19 +20,19 @@ So let's get started.
 
 # Basic Structure of a 3d Printer CANBus
 
-In all likelyhood you are looking to hook up a single CAN toolhead board to your printer to minimise wiring from mainboard to toolhead, so that is the setup we'll be focusing on. 
+In all likelyhood you are looking to hook up a single CAN toolhead board to your printer to minimise wiring from mainboard to toolhead, so that is the setup we'll be focusing on.
 In order to achieve a functioning CAN network on your printer you need 3 things: A computer running the main Klipper software (usually a Raspberry Pi, but anything with a USB port will work for this guide), a CAN network adapter (either a standalone USB device or running a compatible mainboard in klipper's usb-can bridge mode) and a CAN node (the toolhead device). This is also the order in which you need to set things up. No point setting everything up on the toolhead CAN board if you don't have a way for the Pi to talk to it.
 We are going to assume you have a functioning Pi (or equivelant) running linux and already have Klippper, Moonraker, some sort of GUI (Fluidd/Mainsail/Octoprint), and you have the ability to SSH into it.
 
-# Regarding CAN***BOOT***
+# Regarding Katapult (formerly known as CanBoot)
 
-You may have seen other guides have installing CanBOOT onto devices as a first step. CanBOOT is a custom firmware and allows flashing of Klipper to the devices via the CAN network so you don't have to plug a USB cable in each time to flash/update klipper. CanBOOT is really handy but it is ***NOT*** mandatory. This will be discussed later, but Klipper will happily run over a CAN network with or without CanBOOT. 
+You may have seen other guides have installing Katapult/CanBOOT onto devices as a first step. Katapult is a custom firmware and allows flashing of Klipper to the devices via the CAN network so you don't have to plug a USB cable in each time to flash/update klipper. Katapult is really handy but it is ***NOT*** mandatory. This will be discussed later, but Klipper will happily run over a CAN network with or without Katapult.
 
 # can0 file, CAN Speeds, and Transmit Queue Length
 
 This step usually comes later, but as it is common across all different variants we may as well get it done first. In order to dictate the speed at which your CAN network runs at you will need to create (or modify) a "can0" file on your Pi. This is what will tell linux "Hey, you now have a new network interface called can0 that you can send CAN traffic over". To do this first SSH to your Pi and run the command:
   ```
-  sudo nano /etc/network/interfaces.d/can0 
+  sudo nano /etc/network/interfaces.d/can0
   ```
   ![image](https://user-images.githubusercontent.com/124253477/221327674-fad20589-1a5b-4d68-b2d9-2596553f64ab.png)
 
@@ -43,13 +43,13 @@ This will open (or create if it doesn't exist) a file called 'can0' in which you
     bitrate 1000000
     up ip link set can0 txqueuelen 1024
   ```
- 
+
 ![image](https://user-images.githubusercontent.com/124253477/221378593-9a0fcdb5-082c-454e-94bd-08a6dc449d34.png)
 
 Press Ctrl+X to save the can0 file.
- 
+
 The "allow-hotplug" helps the CAN nodes come back online when doing a "firmware_restart" within Klipper.
-"bitrate" dictates the speed at which your CAN network runs at. Kevin O'Connor (of Klipper fame) recommends a 1M speed for this to help with high-bandwidth and timing-critical operations (ADXL Shaper calibration and mesh probing for example). 
+"bitrate" dictates the speed at which your CAN network runs at. Kevin O'Connor (of Klipper fame) recommends a 1M speed for this to help with high-bandwidth and timing-critical operations (ADXL Shaper calibration and mesh probing for example).
 To complement a high bitrate, setting a high transmit queue length "txqueuelen" of 1024 helps minimise "Timer too close" errors.
 
 Once the can0 file is created just reboot the Pi with a `sudo reboot` and move on to the next step.
@@ -83,7 +83,7 @@ The BTT U2C V2.1 was released with bad firmware which although would show up to 
 
 # Klipper USB to CAN bus bridge
 
-The second way of setting up a CAN network is to use the printer mainboard itself as a CAN adapter. 
+The second way of setting up a CAN network is to use the printer mainboard itself as a CAN adapter.
 
 **If you are using a dedicated CAN adapter as above then you don't need this step. Your mainboard will be flashed the same as any other "normal" klipper install**
 

--- a/can_adapter/BigTreeTech U2C v2.1/README.md
+++ b/can_adapter/BigTreeTech U2C v2.1/README.md
@@ -5,7 +5,7 @@ cd ~/
 wget https://github.com/Esoterical/voron_canbus/raw/main/can_adapter/BigTreeTech%20U2C%20v2.1/G0B1_U2C_V2.bin
 ```
 
-(you can read about the error at https://github.com/Arksine/CanBoot/issues/44)
+(you can read about the error at https://github.com/Arksine/katapult/issues/44)
 
 If you used the wget link the firmware should now be in your home directory. Press the boot button on the U2C while plugging it in to your Pi to put it into DFU mode.
 

--- a/can_adapter/Makerbase UTC 1.0/README.md
+++ b/can_adapter/Makerbase UTC 1.0/README.md
@@ -17,13 +17,13 @@ Identify the SWD header on your board, highlighted below:
 
 ![image](https://user-images.githubusercontent.com/124253477/221704780-4e5a6603-b258-4876-9fb6-516029574300.png)
 
-Note that Pin 1 is on the top right.  
-You want to connect to your STLink it like such:  
-Pin 1: SWDIO  
-Pin 2: +3.3V  
-Pin 3: SWCLK  
-Pin 4: Ground  
-Pin 5: Reset  
+Note that Pin 1 is on the top right.
+You want to connect to your STLink it like such:
+Pin 1: SWDIO
+Pin 2: +3.3V
+Pin 3: SWCLK
+Pin 4: Ground
+Pin 5: Reset
 Once that is all connected. Connect your STLink device to your USB port and open up
 STM32CubeProgrammer. Set the interface to ST-Link, setup the configuration like
 below, and hit connect. If you’ve never connected this STLink before, reset mode is the
@@ -51,23 +51,23 @@ CandleLight is better for this sort of thing. We will be using marckleinebudde�
 multichannel fork – note that it is still a WIP fork, so there may be bugs, but it seems to
 work well enough for our purposes
 
-cd ~ 
-sudo apt-get install gcc-arm-none-eabi  
-git clone https://github.com/marckleinebudde/candleLight_fw  
-cd ~/candleLight_fw  
-git checkout multichannel  
-mkdir build  
-cd build  
-cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/gcc-arm-none-eabi-8-2019-q3-update.cmake  
-make budgetcan_fw  
+cd ~
+sudo apt-get install gcc-arm-none-eabi
+git clone https://github.com/marckleinebudde/candleLight_fw
+cd ~/candleLight_fw
+git checkout multichannel
+mkdir build
+cd build
+cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/gcc-arm-none-eabi-8-2019-q3-update.cmake
+make budgetcan_fw
 
-now plugin your UTC in boot mode and type:  
-make flash-budgetcan_fw  
+now plugin your UTC in boot mode and type:
+make flash-budgetcan_fw
 
 After that you can reset your UTC and you can setup your can-bus similarly to a U2C or
-UTOC setup.  
+UTOC setup.
 If you do wish to use klipper instead of CandelLight, you can use the following settings
-for CanBoot and klipper respectively
+for katapult and klipper respectively
 
 ![image](https://user-images.githubusercontent.com/124253477/221706131-6c538194-5a92-42e4-8078-e6ae88f78028.png)
 

--- a/mainboard_flashing/README.md
+++ b/mainboard_flashing/README.md
@@ -97,7 +97,7 @@ If the above command didn't show a 'katapult' device, or threw a "no such file o
 
 Run this command to install klipper firmware via Katapult via USB. Use the device ID you just retrieved in the above ls command.
 
-`python3 ~/katapult/scripts/flash_can.py -f ~/klipper/out/klipper.bin -d /dev/serial/by-id/usb-katapult_stm32f446xx_37001A001851303439363932-if00`
+`python3 ~/katapult/scripts/flashtool.py -f ~/klipper/out/klipper.bin -d /dev/serial/by-id/usb-katapult_stm32f446xx_37001A001851303439363932-if00`
 
 ## If you are running a stock bootloader and flashing via SD card INSTEAD of Katapult
 
@@ -158,7 +158,7 @@ So to update your Katapult, you just need to flash this deployer.bin file via yo
 
 If you already have a functioning CAN setup, and your [mcu] canbus_uuid is in your printer.cfg, then you can force Katapult to reboot into Katapult mode by running:
 
-`python3 ~/katapult/scripts/flash_can.py -i can0 -u yourmainboarduuid -r`
+`python3 ~/katapult/scripts/flashtool.py -i can0 -u yourmainboarduuid -r`
 
 ![image](https://user-images.githubusercontent.com/124253477/223303347-385ec07c-5211-42d3-b985-4dc38c2864ec.png)
 
@@ -170,7 +170,7 @@ You can verify it is in the proper mode by running `ls /dev/serial/by-id`. If yo
 
 Once you are at this stage you can flash the deployer.bin by running:
 
-`python3 ~/katapult/scripts/flash_can.py -f ~/katapult/out/deployer.bin -d /dev/serial/by-id/usb-katapult_stm32f446xx_37001A001851303439363932-if00`
+`python3 ~/katapult/scripts/flashtool.py -f ~/katapult/out/deployer.bin -d /dev/serial/by-id/usb-katapult_stm32f446xx_37001A001851303439363932-if00`
 
 and your Katapult should update.
 
@@ -182,7 +182,7 @@ To update Klipper, first compile the new Klipper firmware by running the same wa
 
 If you already have a functioning CAN setup, and your [mcu] canbus_uuid is in your printer.cfg, then you can force Katapult to reboot into Katapult mode by running:
 
-`python3 ~/katapult/scripts/flash_can.py -i can0 -u yourmainboarduuid -r`
+`python3 ~/katapult/scripts/flashtool.py -i can0 -u yourmainboarduuid -r`
 
 ![image](https://user-images.githubusercontent.com/124253477/223303347-385ec07c-5211-42d3-b985-4dc38c2864ec.png)
 
@@ -194,7 +194,7 @@ You can verify it is in the proper mode by running `ls /dev/serial/by-id`. If yo
 
 Then you can run the same command you used to initially flash Klipper:
 
-`python3 ~/katapult/scripts/flash_can.py -f ~/klipper/out/klipper.bin -d /dev/serial/by-id/usb-katapult_stm32f446xx_37001A001851303439363932-if00`
+`python3 ~/katapult/scripts/flashtool.py -f ~/klipper/out/klipper.bin -d /dev/serial/by-id/usb-katapult_stm32f446xx_37001A001851303439363932-if00`
 
 ## Updating Klipper Firmware via other methods
 

--- a/mainboard_flashing/README.md
+++ b/mainboard_flashing/README.md
@@ -1,14 +1,13 @@
-
 # General Info
 
-The following should be taken as an overall guide on what you are going to be achieving. 
+The following should be taken as an overall guide on what you are going to be achieving.
 
 **PLEASE DO NOT TAKE THE SCREENSHOTS/CONFIGURATIONS ON THIS PAGE EXACTLY AS WRTTEN AS THEY MAY NOT BE COMPATIBLE WITH YOUR PARTICULAR MAINBOARD**
 
-You will need to adapt the below instructions so they cover *your* board's specicific configuration. There are also some included configurations for specific popular boards in the https://github.com/Esoterical/voron_canbus/tree/main/mainboard_flashing/common_hardware folder.
-
+You will need to adapt the below instructions so they cover _your_ board's specicific configuration. There are also some included configurations for specific popular boards in the https://github.com/Esoterical/voron_canbus/tree/main/mainboard_flashing/common_hardware folder.
 
 Before doing anything it is good to have some dependencies installed. Do this by running these on your Pi:
+
 ```
 sudo apt update
 sudo apt upgrade
@@ -16,63 +15,64 @@ sudo apt install python3 python3-pip python3-can
 pip3 install pyserial
 ```
 
-As mentioned in the main guide, you can either use CanBOOT on your mainboard to facilitate flashing over CAN, or you can go without and have the board boot straight into klipper.
+As mentioned in the main guide, you can either use Katapult on your mainboard to facilitate flashing over CAN, or you can go without and have the board boot straight into klipper.
 
-# Installing CanBOOT
+# Installing Katapult
 
 (The following is a lot of copy-paste from MastahFR's excellent "Octopus and SB2040" install guide https://github.com/akhamar/voron_canbus_octopus_sb2040. Give all kudus to them)
 
-First you need to clone the CanBOOT repo onto your pi. Run the following commands to clone the repo:
+First you need to clone the Katapult repo onto your pi. Run the following commands to clone the repo:
+
 ```
 cd ~
-git clone https://github.com/Arksine/CanBoot
+git clone https://github.com/Arksine/katapult
 ```
 
-This will clone the CanBoot repo into a new folder in your home directory called "CanBoot" (and yes, it's case sensitive on both the C and the B).
+This will clone the Katapult repo into a new folder in your home directory called "katapult".
 
-To configure the CanBoot firmware, run these commands to change into the CanBoot directory and then modify the firmware menu:
+To configure the Katapult firmware, run these commands to change into the katapult directory and then modify the firmware menu:
+
 ```
-cd ~/CanBoot
+cd ~/katapult
 make menuconfig
 ```
-You want the Processor, Clock Reference, and Application Start offset to be set as per whatever board you are running. Keep the "Build CanBoot Deployment Application" to (do not build), and make sure "Communication Interface" is set to USB. Also make sure the "Support bootloader entry on rapid double click of reset button" is marked. It makes it so a double press of the reset button will force the board into CanBOOT mode. Makes re-flashing after a mistake a lot easier.
+
+You want the Processor, Clock Reference, and Application Start offset to be set as per whatever board you are running. Keep the "Build Katapult deployment application" to (do not build), and make sure "Communication Interface" is set to USB. Also make sure the "Support bootloader entry on rapid double click of reset button" is marked. It makes it so a double press of the reset button will force the board into Katapult mode. Makes re-flashing after a mistake a lot easier.
 
 ![image](https://user-images.githubusercontent.com/124253477/221333924-0a4d3c28-d084-4f8c-b93f-0670114bd090.png)
 
 Press Q to quit the menu (it will ask to save, choose yes).
 
-Compile the firmware with `make`. You will now have a canboot.bin at in your ~/CanBoot/out/canboot.bin.
+Compile the firmware with `make`. You will now have a katapult.bin at in your ~/katapult/out/katapult.bin.
 
 To flash, connect your mainboard to the Pi via USB then put the mainboard into DFU mode (your mainboard user manual should have instructions on doing this).
 To confirm it's in DFU mode you can run the command `dfu-util -l` and it will show any devices connected to your Pi in DFU mode.
 
 ![image](https://user-images.githubusercontent.com/124253477/221337550-560128dd-b5fd-41ba-8881-48d24b2215ef.png)
 
-> Note the address of *Internal Flash* => 0x08000000
+> Note the address of _Internal Flash_ => 0x08000000
 >
 > Note the address of the usb device => 0483:df11
 
-You can then flash the CanBOOT firmware to your mainboard by running
+You can then flash the Katapult firmware to your mainboard by running
+
 ```
-cd ~/CanBoot
+cd ~/katapult
 make
-dfu-util -R -a 0 -s 0x08000000:force:mass-erase:leave -D ~/CanBoot/out/canboot.bin -d 0483:df11
+dfu-util -R -a 0 -s 0x08000000:force:mass-erase:leave -D ~/katapult/out/katapult.bin -d 0483:df11
 ```
 
-where the --dfuse-address is the *Internal Flash* and the -d is the USB Device ID is the that you grabbed from the `dfu-util -l` command.
+where the --dfuse-address is the _Internal Flash_ and the -d is the USB Device ID is the that you grabbed from the `dfu-util -l` command.
 
 If the result shows an "Error during download get_status" or something, but above it it still has "File downloaded successfullY" then it still flashed OK and you can ignore that error.
 
 ![image](https://user-images.githubusercontent.com/124253477/225469341-46f3478a-aa96-4378-8d73-96faa90d561c.png)
 
+Katapult should now be successfully flashed. Take your mainboard out of DFU mode (it might require removing jumpers and rebooting, or just rebooting).
 
-CanBOOT should now be successfully flashed. Take your mainboard out of DFU mode (it might require removing jumpers and rebooting, or just rebooting).
+As you are installing Katapult onto the mainboard that you are also going to use for USB-CAN-Bridge mode klipper, you still will _not_ have a working CAN network at this stage. You can flash klipper to your mainboard via Katapult, but in reality it is flashing over USB and not flashing over CAN.
 
-As you are installing CanBOOT onto the mainboard that you are also going to use for USB-CAN-Bridge mode klipper, you still will *not* have a working CAN network at this stage. You can flash klipper to your mainboard via CanBOOT, but in reality it is flashing over USB and not flashing over CAN.
-
-Flashing klipper via CanBOOT will be covered shortly.
-
-
+Flashing klipper via Katapult will be covered shortly.
 
 # Installing USB-CAN-Bridge Klipper
 
@@ -83,29 +83,27 @@ Then go into the klipper configuration menu by running:
 
 You want the Processor and Clock Reference to be set as per whatever board you are running. Set Communication interface to 'USB to CAN bus bridge' then set the CAN Bus interface to use the pins that are specific to your mainboard. Also set the CAN bus speed to the same as the speed in your can0 file. In this guide it is set to 1000000.
 
-**NOTE: The Bootloader offset will be determined by if you are using a bootloader or not. If you are keeping the stock bootloader, or have installed canboot, then set the bootloader offset to the recommendation in the manual. If you are going to run without a bootloader then set the bootloader offset to "No Bootloader"**
+**NOTE: The Bootloader offset will be determined by if you are using a bootloader or not. If you are keeping the stock bootloader, or have installed Katapult, then set the bootloader offset to the recommendation in the manual. If you are going to run without a bootloader then set the bootloader offset to "No Bootloader"**
 
 Once you have the firmware configured, run a `make clean` to make sure there are no old files hanging around, then `make` to compile the firmware. It will save the firmware to ~/klipper/out/klipper.bin
 
+## If you have Katapult installed
 
-## If you have CanBOOT installed
-
-Run an `ls /dev/serial/by-id/` and take note of the CanBoot device that it shows:
+Run an `ls /dev/serial/by-id/` and take note of the Katapult device that it shows:
 
 ![image](https://user-images.githubusercontent.com/124253477/221342447-a98e6bee-050b-4f82-a4cb-1265e92d0752.png)
 
-If the above command didn't show a 'canboot' device, or threw a "no such file or directory" error, then quickly double-click the RESET button on your mainboard and run the command again. Until you get a result from a `ls /dev/serial/by-id/` there is no point doing further steps below.
+If the above command didn't show a 'katapult' device, or threw a "no such file or directory" error, then quickly double-click the RESET button on your mainboard and run the command again. Until you get a result from a `ls /dev/serial/by-id/` there is no point doing further steps below.
 
-Run this command to install klipper firmware via canboot via USB. Use the device ID you just retrieved in the above ls command.
+Run this command to install klipper firmware via Katapult via USB. Use the device ID you just retrieved in the above ls command.
 
-`python3 ~/CanBoot/scripts/flash_can.py -f ~/klipper/out/klipper.bin -d /dev/serial/by-id/usb-CanBoot_stm32f446xx_37001A001851303439363932-if00`
+`python3 ~/katapult/scripts/flash_can.py -f ~/klipper/out/klipper.bin -d /dev/serial/by-id/usb-katapult_stm32f446xx_37001A001851303439363932-if00`
 
-
-## If you are running a stock bootloader and flashing via SD card INSTEAD of CanBOOT
+## If you are running a stock bootloader and flashing via SD card INSTEAD of Katapult
 
 Simply follow the mainboard user manual to copy the ~/klipper/out/klipper.bin file to an SD card (renaming it if needed) and flash the mainboard as per user manual.
 
-## If you are flashing via DFU mode (no CanBOOT or stock bootloader)
+## If you are flashing via DFU mode (no Katapult or stock bootloader)
 
 To flash, connect your mainboard to the Pi via USB then put the mainboard into DFU mode (your mainboard user manual should have instructions on doing this).
 To confirm it's in DFU mode you can run the command `dfu-util -l` and it will show any devices connected to your Pi in DFU mode.
@@ -115,6 +113,7 @@ To confirm it's in DFU mode you can run the command `dfu-util -l` and it will sh
 > Note the address of the usb device => 0483:df11
 
 Then simply run the following commands to change to the klipper directory then flash the mainboard.
+
 ```
 cd ~/klipper
 make flash FLASH_DEVICE=0483:df11
@@ -140,77 +139,63 @@ You can now run the Klipper canbus query to retrieve the canbus_uuid of your mai
 
 Use this UUID in the [mcu] section of your printer.cfg in order for Klipper (on Pi) to connect to the mainboard.
 
-
-
-
 # UPDATING
 
-## Updating CanBOOT
+## Updating Katapult
 
-You should never really have to update your CanBOOT on the mainboard. Even if you wish to change your CanBUS speeds you don't need to change CanBOOT **On the Mainboard** as it only communicates via USB and not via CAN.
+You should never really have to update your Katapult on the mainboard. Even if you wish to change your CanBUS speeds you don't need to change Katapult **On the Mainboard** as it only communicates via USB and not via CAN.
 
-However, if you need to update CanBOOT for whatever reason, then:  
-Change to your CanBoot directory with `cd ~/CanBoot`  
-then go into the CanBoot firmware config menu with `make menuconfig`  
-This time **make sure "Build CanBoot deployment application" is configured** with the properly bootloader offset (same as the "Application start offset" that is relevant for your mainboard). Make sure all the rest of your settings are correct for your mainboard.
+However, if you need to update Katapult for whatever reason, then:
+Change to your Katapult directory with `cd ~/katapult`
+then go into the Katapult firmware config menu with `make menuconfig`
+This time **make sure "Build Katapult deployment application" is configured** with the properly bootloader offset (same as the "Application start offset" that is relevant for your mainboard). Make sure all the rest of your settings are correct for your mainboard.
 
 ![image](https://user-images.githubusercontent.com/124253477/223301620-c1fd3d16-04e3-49ce-8d48-5498811f4c46.png)
 
-This time when you run `make`, along with the normal canboot.bin file it will also generate a deployer.bin file. This deployer.bin is a fancy little tool that uses the existing bootloader (canboot, or stock, or whatever) to "update" itself into the canboot you just compiled.
+This time when you run `make`, along with the normal katapult.bin file it will also generate a deployer.bin file. This deployer.bin is a fancy little tool that uses the existing bootloader (Katapult, or stock, or whatever) to "update" itself into the Katapult you just compiled.
 
-So to update your canboot, you just need to flash this deployer.bin file via your existing canboot (in a very similar way you would flash klipper via canboot).
+So to update your Katapult, you just need to flash this deployer.bin file via your existing Katapult (in a very similar way you would flash klipper via Katapult).
 
-If you already have a functioning CAN setup, and your [mcu] canbus_uuid is in your printer.cfg, then you can force CanBOOT to reboot into canboot mode by running:
+If you already have a functioning CAN setup, and your [mcu] canbus_uuid is in your printer.cfg, then you can force Katapult to reboot into Katapult mode by running:
 
-`python3 ~/CanBoot/scripts/flash_can.py -i can0 -u yourmainboarduuid -r`
+`python3 ~/katapult/scripts/flash_can.py -i can0 -u yourmainboarduuid -r`
 
 ![image](https://user-images.githubusercontent.com/124253477/223303347-385ec07c-5211-42d3-b985-4dc38c2864ec.png)
 
-If you don't have the UUID (or something has gone wrong with the klipper firmware and your mainboard is hung) then you can also double-press the RESET button on your mainboard to force CanBOOT to reboot into canboot mode.
+If you don't have the UUID (or something has gone wrong with the klipper firmware and your mainboard is hung) then you can also double-press the RESET button on your mainboard to force Katapult to reboot into Katapult mode.
 
-You can verify it is in the proper mode by running `ls /dev/serial/by-id`. If you see a "usb-CanBoot-......" device then it is good to go.
+You can verify it is in the proper mode by running `ls /dev/serial/by-id`. If you see a "usb-katapult-......" device then it is good to go.
 
 ![image](https://user-images.githubusercontent.com/124253477/223303596-f7709d3c-d652-401c-959d-560381a39cff.png)
 
 Once you are at this stage you can flash the deployer.bin by running:
 
-`python3 ~/CanBoot/scripts/flash_can.py -f ~/CanBoot/out/deployer.bin -d /dev/serial/by-id/usb-CanBoot_stm32f446xx_37001A001851303439363932-if00`
+`python3 ~/katapult/scripts/flash_can.py -f ~/katapult/out/deployer.bin -d /dev/serial/by-id/usb-katapult_stm32f446xx_37001A001851303439363932-if00`
 
-and your CanBoot should update.
+and your Katapult should update.
 
 ![image](https://user-images.githubusercontent.com/124253477/223303940-e7c19b00-04bb-47b3-9230-458e9f2de251.png)
 
-## Updating Klipper Firmware via CanBOOT
+## Updating Klipper Firmware via Katapult
 
-To update Klipper, first compile the new Klipper firmware by running the same way you did in the "Installing USB-CAN-Bridge Klipper" section above, but with your new settings (if you are changing settings). Then you need to get CanBOOT back into canboot mode.
+To update Klipper, first compile the new Klipper firmware by running the same way you did in the "Installing USB-CAN-Bridge Klipper" section above, but with your new settings (if you are changing settings). Then you need to get Katapult back into Katapult mode.
 
-If you already have a functioning CAN setup, and your [mcu] canbus_uuid is in your printer.cfg, then you can force CanBOOT to reboot into canboot mode by running:
+If you already have a functioning CAN setup, and your [mcu] canbus_uuid is in your printer.cfg, then you can force Katapult to reboot into Katapult mode by running:
 
-`python3 ~/CanBoot/scripts/flash_can.py -i can0 -u yourmainboarduuid -r`
+`python3 ~/katapult/scripts/flash_can.py -i can0 -u yourmainboarduuid -r`
 
 ![image](https://user-images.githubusercontent.com/124253477/223303347-385ec07c-5211-42d3-b985-4dc38c2864ec.png)
 
-If you don't have the UUID (or something has gone wrong with the klipper firmware and your mainboard is hung) then you can also double-press the RESET button on your mainboard to force CanBOOT to reboot into canboot mode.
+If you don't have the UUID (or something has gone wrong with the klipper firmware and your mainboard is hung) then you can also double-press the RESET button on your mainboard to force Katapult to reboot into Katapult mode.
 
-You can verify it is in the proper mode by running `ls /dev/serial/by-id`. If you see a "usb-CanBoot-......" device then it is good to go.
+You can verify it is in the proper mode by running `ls /dev/serial/by-id`. If you see a "usb-katapult-......" device then it is good to go.
 
 ![image](https://user-images.githubusercontent.com/124253477/223303596-f7709d3c-d652-401c-959d-560381a39cff.png)
 
 Then you can run the same command you used to initially flash Klipper:
 
-`python3 ~/CanBoot/scripts/flash_can.py -f ~/klipper/out/klipper.bin -d /dev/serial/by-id/usb-CanBoot_stm32f446xx_37001A001851303439363932-if00`
+`python3 ~/katapult/scripts/flash_can.py -f ~/klipper/out/klipper.bin -d /dev/serial/by-id/usb-katapult_stm32f446xx_37001A001851303439363932-if00`
 
 ## Updating Klipper Firmware via other methods
 
 Updating klipper via SD card flash or straight DFU mode is the exact same as initially installing it as outlined in the main Installing section above.
-
-
-
-
-
-
-
-
-
-
-

--- a/mainboard_flashing/common_hardware/BigTreeTech Manta E3EZ/readme.MD
+++ b/mainboard_flashing/common_hardware/BigTreeTech Manta E3EZ/readme.MD
@@ -1,11 +1,11 @@
-# CanBOOT Config
+# Katapult Config
 
 ![image](https://user-images.githubusercontent.com/124253477/235831073-92c31a1a-d252-4deb-9f94-e4f2e755881d.png)
 
-# Klipper USB-CAN-Bridge when using CanBOOT or stock bootloader
+# Klipper USB-CAN-Bridge when using Katapult or stock bootloader
 
 ![image](https://user-images.githubusercontent.com/124253477/235831140-66b78a6f-5f3b-403b-9383-037caf9b1eee.png)
 
-# Klipper USB-CAN-Bridge when **NOT** using CanBOOT or stock bootloader
+# Klipper USB-CAN-Bridge when **NOT** using Katapult or stock bootloader
 
 ![image](https://user-images.githubusercontent.com/124253477/235831161-232e2e0c-bf09-4101-9f93-10061dbb5260.png)

--- a/mainboard_flashing/common_hardware/BigTreeTech Manta M8P v1.1/README.md
+++ b/mainboard_flashing/common_hardware/BigTreeTech Manta M8P v1.1/README.md
@@ -1,9 +1,9 @@
-# BTT Manta M8P with CB1 v1.1 
+# BTT Manta M8P with CB1 v1.1
 ## IMPORTANT note - you will need to add a jumper to the 120R (J14) on both the mainboard and the CAN toolhead.
 
 # STM32G0B1
 
-## CanBOOT Config (note this just uses the default USB communication interface)
+## Katapult Config (note this just uses the default USB communication interface)
 ![image](https://user-images.githubusercontent.com/14154875/225157525-d1b8f813-ab11-4f59-87fa-45f8a3ee2a6a.png)
 
 

--- a/mainboard_flashing/common_hardware/BigTreeTech Octopus Max EZ/README.md
+++ b/mainboard_flashing/common_hardware/BigTreeTech Octopus Max EZ/README.md
@@ -1,12 +1,12 @@
-# CanBOOT Config
+# Katapult Config
 
 ![image](https://github.com/Esoterical/voron_canbus/assets/124253477/2bcacb62-eb25-47ef-818c-de6506d94dee)
 
-# Klipper USB-CAN-Bridge when using CanBOOT or stock bootloader
+# Klipper USB-CAN-Bridge when using Katapult or stock bootloader
 
 ![image](https://user-images.githubusercontent.com/124253477/221387725-5b28da97-6f3b-4e48-86db-46811023a2b7.png)
 
-# Klipper USB-CAN-Bridge when **NOT** using CanBOOT or stock bootloader
+# Klipper USB-CAN-Bridge when **NOT** using Katapult or stock bootloader
 
 ![image](https://user-images.githubusercontent.com/124253477/221387734-6128e816-68ce-42b5-b3f1-c13f201a631d.png)
 

--- a/mainboard_flashing/common_hardware/BigTreeTech Octopus/README.md
+++ b/mainboard_flashing/common_hardware/BigTreeTech Octopus/README.md
@@ -8,56 +8,56 @@ To put the octopus into DFU mode you need to put in the boot jumper (purple) and
 **The BTT Octopus comes in many variations of MCU chip. Make sure you pick the correct config for the MCU chip you have**
 
 # STM32F446
-## CanBOOT Config
+## Katapult Config
 
 ![image](https://user-images.githubusercontent.com/124253477/221378011-0d10ed13-a789-4390-a275-394358423f24.png)
 
-## Klipper USB-CAN-Bridge when using CanBOOT or stock bootloader
+## Klipper USB-CAN-Bridge when using Katapult or stock bootloader
 
 ![image](https://user-images.githubusercontent.com/124253477/221378034-ac82a51e-6ba7-4288-8186-91a6733dbd2f.png)
 
-## Klipper USB-CAN-Bridge when **NOT** using CanBOOT or stock bootloader
+## Klipper USB-CAN-Bridge when **NOT** using Katapult or stock bootloader
 
 ![image](https://user-images.githubusercontent.com/124253477/221378044-0cfe2461-8a83-4df4-92ed-4ae55311824a.png)
 
 
 # STM32F429
-## CanBOOT Config
+## Katapult Config
 
 ![image](https://user-images.githubusercontent.com/124253477/221378344-0b34301c-8927-4bb0-b05b-90eeb9ba623a.png)
 
-## Klipper USB-CAN-Bridge when using CanBOOT or stock bootloader
+## Klipper USB-CAN-Bridge when using Katapult or stock bootloader
 
 ![image](https://user-images.githubusercontent.com/124253477/221378352-e22e8719-6a26-499a-9f9f-375c0baa1cd6.png)
 
-## Klipper USB-CAN-Bridge when **NOT** using CanBOOT or stock bootloader
+## Klipper USB-CAN-Bridge when **NOT** using Katapult or stock bootloader
 
 ![image](https://user-images.githubusercontent.com/124253477/221378367-c8490b7a-1807-47db-a983-2bf6ce1dc114.png)
 
 
 # STM32F407
-## CanBOOT Config
+## Katapult Config
 
 ![image](https://user-images.githubusercontent.com/124253477/221378446-5693153d-0b8f-4fa5-988e-6e4e2b8b3485.png)
 
-## Klipper USB-CAN-Bridge when using CanBOOT or stock bootloader
+## Klipper USB-CAN-Bridge when using Katapult or stock bootloader
 
 ![image](https://user-images.githubusercontent.com/124253477/221378459-561064a6-deaa-4590-85b9-058f480871e2.png)
 
-## Klipper USB-CAN-Bridge when **NOT** using CanBOOT or stock bootloader
+## Klipper USB-CAN-Bridge when **NOT** using Katapult or stock bootloader
 
 ![image](https://user-images.githubusercontent.com/124253477/221378467-55beda81-041e-4c7a-b226-bce55ee067cd.png)
 
 
 # STM32H723
-## CanBOOT Config
+## Katapult Config
 
 ![image](https://user-images.githubusercontent.com/124253477/221378486-b40ba07e-38fb-4e4d-90ed-97a7df56b7d6.png)
 
-## Klipper USB-CAN-Bridge when using CanBOOT or stock bootloader
+## Klipper USB-CAN-Bridge when using Katapult or stock bootloader
 
 ![image](https://user-images.githubusercontent.com/124253477/221378502-d3aee8c7-c4ba-42da-838b-3e64cfc6262d.png)
 
-## Klipper USB-CAN-Bridge when **NOT** using CanBOOT or stock bootloader
+## Klipper USB-CAN-Bridge when **NOT** using Katapult or stock bootloader
 
 ![image](https://user-images.githubusercontent.com/124253477/221378519-f32fc144-0f13-4d4e-b792-fcea1e9a893c.png)

--- a/mainboard_flashing/common_hardware/BigTreeTech SKR Pico/README.md
+++ b/mainboard_flashing/common_hardware/BigTreeTech SKR Pico/README.md
@@ -1,13 +1,13 @@
 
-# CanBOOT Config
+# Katapult Config
 
 ![image](https://user-images.githubusercontent.com/124253477/221390508-c6fdd63a-f4af-46e1-b100-ee90dd723bf8.png)
 
-# Klipper USB-CAN-Bridge when using CanBOOT or stock bootloader
+# Klipper USB-CAN-Bridge when using Katapult or stock bootloader
 
 ![image](https://user-images.githubusercontent.com/124253477/221390518-b7f15c58-6beb-43bd-a47b-d6823956e997.png)
 
-# Klipper USB-CAN-Bridge when **NOT** using CanBOOT or stock bootloader
+# Klipper USB-CAN-Bridge when **NOT** using Katapult or stock bootloader
 
 ![image](https://user-images.githubusercontent.com/124253477/221390533-cdc390ca-eaaf-4771-a9b7-cad1d2cbfaee.png)
 

--- a/mainboard_flashing/common_hardware/BigTreeTech SKR-3 & SKR-3EZ/README.md
+++ b/mainboard_flashing/common_hardware/BigTreeTech SKR-3 & SKR-3EZ/README.md
@@ -1,11 +1,11 @@
-# CanBOOT Config
+# Katapult Config
 
 ![image](https://user-images.githubusercontent.com/124253477/236376883-34ae7805-365a-40ad-a5fc-f613e9d1fc4d.png)
 
-# Klipper USB-CAN-Bridge when using CanBOOT or stock bootloader
+# Klipper USB-CAN-Bridge when using Katapult or stock bootloader
 
 ![image](https://user-images.githubusercontent.com/124253477/236376937-172778da-ba61-45af-b64e-ed1b2d79f51b.png)
 
-# Klipper USB-CAN-Bridge when **NOT** using CanBOOT or stock bootloader
+# Klipper USB-CAN-Bridge when **NOT** using Katapult or stock bootloader
 
 ![image](https://user-images.githubusercontent.com/124253477/236376954-7d76d0d8-e39e-4fd6-84de-8380abec4efe.png)

--- a/mainboard_flashing/common_hardware/Fysetc Spider v1.0/README.md
+++ b/mainboard_flashing/common_hardware/Fysetc Spider v1.0/README.md
@@ -1,13 +1,13 @@
 
-# CanBOOT Config
+# Katapult Config
 
 ![image](https://user-images.githubusercontent.com/124253477/221349790-d073d222-1061-4c81-a7eb-796a8693b621.png)
 
-# Klipper USB-CAN-Bridge when using CanBOOT or stock bootloader
+# Klipper USB-CAN-Bridge when using Katapult or stock bootloader
 
 ![image](https://user-images.githubusercontent.com/124253477/221349817-d7381c21-fecc-4111-a34b-bf0522cd456e.png)
 
-# Klipper USB-CAN-Bridge when **NOT** using CanBOOT or stock bootloader
+# Klipper USB-CAN-Bridge when **NOT** using Katapult or stock bootloader
 
 ![image](https://user-images.githubusercontent.com/124253477/221349849-b78db57a-fe2d-461e-a026-10112071a60e.png)
 

--- a/mainboard_flashing/common_hardware/Fysetc Spider v2.2/README.md
+++ b/mainboard_flashing/common_hardware/Fysetc Spider v2.2/README.md
@@ -1,12 +1,12 @@
-# CanBOOT Config
+# Katapult Config
 
 ![image](https://user-images.githubusercontent.com/124253477/221349790-d073d222-1061-4c81-a7eb-796a8693b621.png)
 
-# Klipper USB-CAN-Bridge when using CanBOOT or stock bootloader
+# Klipper USB-CAN-Bridge when using Katapult or stock bootloader
 
 ![image](https://user-images.githubusercontent.com/124253477/221349817-d7381c21-fecc-4111-a34b-bf0522cd456e.png)
 
-# Klipper USB-CAN-Bridge when **NOT** using CanBOOT or stock bootloader
+# Klipper USB-CAN-Bridge when **NOT** using Katapult or stock bootloader
 
 ![image](https://user-images.githubusercontent.com/124253477/221349849-b78db57a-fe2d-461e-a026-10112071a60e.png)
 

--- a/mainboard_flashing/common_hardware/Fysetc Spider v2.3/README.md
+++ b/mainboard_flashing/common_hardware/Fysetc Spider v2.3/README.md
@@ -1,14 +1,14 @@
 
 
-# CanBOOT Config
+# Katapult Config
 
 ![image](https://user-images.githubusercontent.com/124253477/221349790-d073d222-1061-4c81-a7eb-796a8693b621.png)
 
-# Klipper USB-CAN-Bridge when using CanBOOT or stock bootloader
+# Klipper USB-CAN-Bridge when using Katapult or stock bootloader
 
 ![image](https://user-images.githubusercontent.com/124253477/221349817-d7381c21-fecc-4111-a34b-bf0522cd456e.png)
 
-# Klipper USB-CAN-Bridge when **NOT** using CanBOOT or stock bootloader
+# Klipper USB-CAN-Bridge when **NOT** using Katapult or stock bootloader
 
 ![image](https://user-images.githubusercontent.com/124253477/221349849-b78db57a-fe2d-461e-a026-10112071a60e.png)
 

--- a/mainboard_flashing/common_hardware/MKS Monster8/README.md
+++ b/mainboard_flashing/common_hardware/MKS Monster8/README.md
@@ -1,8 +1,8 @@
-# CanBOOT Config
+# Katapult Config
 
 ![image](https://user-images.githubusercontent.com/124253477/221387924-afb1784e-823b-48b4-a5d4-3ea08cd09071.png)
 
-# Klipper USB-CAN-Bridge when using CanBOOT
+# Klipper USB-CAN-Bridge when using Katapult
 
 ![image](https://user-images.githubusercontent.com/124253477/221387939-22b5a327-af94-4337-b952-849758bec999.png)
 
@@ -10,7 +10,7 @@
 
 ![image](https://user-images.githubusercontent.com/124253477/221387879-2563d531-a111-4f51-8baa-86f25b0644fa.png)
 
-# Klipper USB-CAN-Bridge when **NOT** using CanBOOT or stock bootloader
+# Klipper USB-CAN-Bridge when **NOT** using Katapult or stock bootloader
 
 ![image](https://user-images.githubusercontent.com/124253477/221387882-2a315259-3623-4168-b4c4-39ad98ef6b37.png)
 

--- a/toolhead_flashing/README.md
+++ b/toolhead_flashing/README.md
@@ -117,17 +117,17 @@ Once you have the firmware configured, run a `make clean` to make sure there are
 
 ## If you have Katapult installed
 
-Run a `python3 ~/katapult/scripts/flash_can.py -i can0 -q` and take note of the Katapult device that it shows:
+Run a `python3 ~/katapult/scripts/flashtool.py -i can0 -q` and take note of the Katapult device that it shows:
 
 ![image](https://user-images.githubusercontent.com/124253477/221345166-bd920eef-8ce9-48ff-9f31-8ebe8da48225.png)
 
 Then run the following command to install klipper firmware via Katapult. Use the UUID you just retrieved in the above query.
 
-`python3 ~/katapult/scripts/flash_can.py -i can0 -u b6d9de35f24f -f ~/klipper/out/klipper.bin`
+`python3 ~/katapult/scripts/flashtool.py -i can0 -u b6d9de35f24f -f ~/klipper/out/klipper.bin`
 
-where the "-u" ID is what you found from the "flash_can.py -i can0 -q" query.
+where the "-u" ID is what you found from the "flashtool.py -i can0 -q" query.
 
-One the flash has been completed you can run the `python3 ~/katapult/scripts/flash_can.py -i can0 -q` command again. This time you should see the same UUID but with "Application: Klipper" instead of "Application: Katapult"
+One the flash has been completed you can run the `python3 ~/katapult/scripts/flashtool.py -i can0 -q` command again. This time you should see the same UUID but with "Application: Klipper" instead of "Application: Katapult"
 
 ![image](https://user-images.githubusercontent.com/124253477/221346236-5633f522-97b6-43e7-a675-82f3e483e3a4.png)
 
@@ -188,19 +188,19 @@ So to update your Katapult, you just need to flash this deployer.bin file via yo
 
 If you already have a functioning CAN setup, and your [mcu toolhead] canbus_uuid is in your printer.cfg, then you can force Katapult to reboot into Katapult mode by running:
 
-`python3 ~/katapult/scripts/flash_can.py -i can0 -u yourtoolheaduuid -r`
+`python3 ~/katapult/scripts/flashtool.py -i can0 -u yourtoolheaduuid -r`
 
 ![image](https://user-images.githubusercontent.com/124253477/223307559-1da6a2dd-d572-456c-9ee6-0565e9192fea.png)
 
 If you don't have the UUID (or something has gone wrong with the klipper firmware and your toolboard is hung) then you can also double-press the RESET button on your toolhead to force Katapult to reboot into Katapult mode.
 
-You can verify it is in the proper mode by running `python3 ~/katapult/scripts/flash_can.py -q`. If you see a "Detected UUID: xxxxxxxxx, Application: Katapult" device then it is good to go.
+You can verify it is in the proper mode by running `python3 ~/katapult/scripts/flashtool.py -q`. If you see a "Detected UUID: xxxxxxxxx, Application: Katapult" device then it is good to go.
 
 ![image](https://user-images.githubusercontent.com/124253477/223307593-b96dc642-9fa0-494b-93b8-a155d14bb535.png)
 
 Once you are at this stage you can flash the deployer.bin by running:
 
-`python3 ~/katapult/scripts/flash_can.py -i can0 -u b6d9de35f24f -f ~/katapult/out/deployer.bin`
+`python3 ~/katapult/scripts/flashtool.py -i can0 -u b6d9de35f24f -f ~/katapult/out/deployer.bin`
 
 and your Katapult should update.
 
@@ -210,21 +210,21 @@ To update Klipper, first compile the new Klipper firmware by running the same wa
 
 If you already have a functioning CAN setup, and your [mcu toolhead] canbus_uuid is in your printer.cfg, then you can force Katapult to reboot into Katapult mode by running:
 
-`python3 ~/katapult/scripts/flash_can.py -i can0 -u yourtoolheaduuid -r`
+`python3 ~/katapult/scripts/flashtool.py -i can0 -u yourtoolheaduuid -r`
 
 ![image](https://user-images.githubusercontent.com/124253477/223307559-1da6a2dd-d572-456c-9ee6-0565e9192fea.png)
 
 If you don't have the UUID (or something has gone wrong with the klipper firmware and your toolboard is hung) then you can also double-press the RESET button on your toolhead to force Katapult to reboot into Katapult mode.
 
-You can verify it is in the proper mode by running `python3 ~/katapult/scripts/flash_can.py -q`. If you see a "Detected UUID: xxxxxxxxx, Application: Katapult" device then it is good to go.
+You can verify it is in the proper mode by running `python3 ~/katapult/scripts/flashtool.py -q`. If you see a "Detected UUID: xxxxxxxxx, Application: Katapult" device then it is good to go.
 
 ![image](https://user-images.githubusercontent.com/124253477/223307593-b96dc642-9fa0-494b-93b8-a155d14bb535.png)
 
 Then you can run the same command you used to initially flash Klipper:
 
-`python3 ~/katapult/scripts/flash_can.py -i can0 -u b6d9de35f24f -f ~/klipper/out/klipper.bin`
+`python3 ~/katapult/scripts/flashtool.py -i can0 -u b6d9de35f24f -f ~/klipper/out/klipper.bin`
 
-One the flash has been completed you can run the `python3 ~/katapult/scripts/flash_can.py -i can0 -q` command again. This time you should see the same UUID but with "Application: Klipper" instead of "Application: Katapult"
+One the flash has been completed you can run the `python3 ~/katapult/scripts/flashtool.py -i can0 -q` command again. This time you should see the same UUID but with "Application: Klipper" instead of "Application: Katapult"
 
 ![image](https://user-images.githubusercontent.com/124253477/221346236-5633f522-97b6-43e7-a675-82f3e483e3a4.png)
 

--- a/toolhead_flashing/README.md
+++ b/toolhead_flashing/README.md
@@ -1,14 +1,13 @@
-
 # General Info
 
-The following should be taken as an overall guide on what you are going to be achieving. 
+The following should be taken as an overall guide on what you are going to be achieving.
 
 **PLEASE DO NOT TAKE THE SCREENSHOTS/CONFIGURATIONS ON THIS PAGE EXACTLY AS WRTTEN AS THEY MAY NOT BE COMPATIBLE WITH YOUR PARTICULAR MAINBOARD**
 
-You will need to adapt the below instructions so they cover *your* board's specicific configuration. There are also some included configurations for specific popular boards in the https://github.com/Esoterical/voron_canbus/tree/main/toolhead_flashing/common_hardware folder.
-
+You will need to adapt the below instructions so they cover _your_ board's specicific configuration. There are also some included configurations for specific popular boards in the https://github.com/Esoterical/voron_canbus/tree/main/toolhead_flashing/common_hardware folder.
 
 Before doing anything it is good to have some dependencies installed. Do this by running these on your Pi:
+
 ```
 sudo apt update
 sudo apt upgrade
@@ -16,30 +15,33 @@ sudo apt install python3 python3-pip python3-can
 pip3 install pyserial
 ```
 
-As mentioned in the main guide, you can either use CanBOOT on your toolhead to facilitate flashing over CAN, or you can go without and have the board boot straight into klipper.
+As mentioned in the main guide, you can either use Katapult on your toolhead to facilitate flashing over CAN, or you can go without and have the board boot straight into klipper.
 
-# Installing CanBOOT
+# Installing Katapult
 
 (The following is a lot of copy-paste from MastahFR's excellent "Octopus and SB2040" install guide https://github.com/akhamar/voron_canbus_octopus_sb2040. Give all kudus to them)
 
-First you need to clone the CanBOOT repo onto your pi. Run the following commands to clone the repo:
+First you need to clone the Katapult repo onto your pi. Run the following commands to clone the repo:
+
 ```
 cd ~
-git clone https://github.com/Arksine/CanBoot
+git clone https://github.com/Arksine/katapult
 ```
 
-This will clone the CanBoot repo into a new folder in your home directory called "CanBoot" (and yes, it's case sensitive on both the C and the B).
+This will clone the Katapult repo into a new folder in your home directory called "katapult".
 
-To configure the CanBoot firmware, run these commands to change into the CanBoot directory and then modify the firmware menu:
+To configure the Katapult firmware, run these commands to change into the katapult directory and then modify the firmware menu:
+
 ```
-cd ~/CanBoot
+cd ~/katapult
 make menuconfig
 ```
-You want the Processor, Clock Reference, and Application Start offset to be set as per whatever board you are running. Make sure "Communication Interface" is set to "CAN bus" with the appropriate pins for your board. Also make sure the "Support bootloader entry on rapid double click of reset button" is marked. It makes it so a double press of the reset button will force the board into CanBOOT mode. Makes re-flashing after a mistake a lot easier.
+
+You want the Processor, Clock Reference, and Application Start offset to be set as per whatever board you are running. Make sure "Communication Interface" is set to "CAN bus" with the appropriate pins for your board. Also make sure the "Support bootloader entry on rapid double click of reset button" is marked. It makes it so a double press of the reset button will force the board into Katapult mode. Makes re-flashing after a mistake a lot easier.
 
 ![image](https://user-images.githubusercontent.com/124253477/221349624-69abcf3e-dfd8-48d0-b4f6-0ebd620f6b42.png)
 
-Compile the firmware with `make`. You will now have a canboot.bin (or canboot.uf2) in your ~/CanBoot/out/ directory.
+Compile the firmware with `make`. You will now have a katapult.bin (or katapult.uf2) in your ~/katapult/out/ directory.
 
 To flash, connect your toolhead board to the Pi via USB then put the toolhead board into DFU/BOOT mode (your toolhead board user manual should have instructions on doing this).
 
@@ -49,16 +51,17 @@ To confirm it's in DFU mode you can run the command `dfu-util -l` and it will sh
 
 ![image](https://user-images.githubusercontent.com/124253477/221337550-560128dd-b5fd-41ba-8881-48d24b2215ef.png)
 
-> Note the address of *Internal Flash* => 0x08000000
+> Note the address of _Internal Flash_ => 0x08000000
 >
 > Note the address of the usb device => 0483:df11
 
-You can then flash the CanBOOT firmware to your toolhead board by running
+You can then flash the Katapult firmware to your toolhead board by running
+
 ```
-dfu-util -R -a 0 -s 0x08000000:force:mass-erase:leave -D ~/CanBoot/out/canboot.bin -d 0483:df11
+dfu-util -R -a 0 -s 0x08000000:force:mass-erase:leave -D ~/katapult/out/katapult.bin -d 0483:df11
 ```
 
-where the --dfuse-address is the *Internal Flash* and the -d is the USB Device ID is the that you grabbed from the `dfu-util -l` command.
+where the --dfuse-address is the _Internal Flash_ and the -d is the USB Device ID is the that you grabbed from the `dfu-util -l` command.
 
 If the result shows an "Error during download get_status" or something, but above it it still has "File downloaded successfullY" then it still flashed OK and you can ignore that error.
 
@@ -72,9 +75,10 @@ To confirm it's in BOOT mode, run an `lsusb` command and you should see the devi
 
 > Note the address of the usb device => 2e8a:0003
 
-You can then flash the CanBOOT firmware to your toolhead board by running
+You can then flash the Katapult firmware to your toolhead board by running
+
 ```
-cd ~/CanBoot
+cd ~/katapult
 make flash FLASH_DEVICE=2e8a:0003
 ```
 
@@ -84,20 +88,19 @@ If the result shows an "Error during download get_status" or something, but abov
 
 ![image](https://user-images.githubusercontent.com/124253477/225469341-46f3478a-aa96-4378-8d73-96faa90d561c.png)
 
-## CanBOOT is now installed
+## Katapult is now installed
 
-CanBOOT should now be successfully flashed. Take your toolhead out of DFU mode (it might require removing jumpers and rebooting, or just rebooting).
+Katapult should now be successfully flashed. Take your toolhead out of DFU mode (it might require removing jumpers and rebooting, or just rebooting).
 
-Wire up your toolhead power (24v and gnd) and CAN (CANH/CANL) wires, then the following command to see if the toolhead board is on the CAN network and waiting in CanBOOT mode
+Wire up your toolhead power (24v and gnd) and CAN (CANH/CANL) wires, then the following command to see if the toolhead board is on the CAN network and waiting in Katapult mode
 
 `~/klippy-env/bin/python3 ~/klipper/scripts/canbus_query.py can0`
 
-You should see a "Found UUID" with "Application: CanBoot"
+You should see a "Found UUID" with "Application: Katapult"
 
 ![image](https://github.com/Esoterical/voron_canbus/assets/2089/47589b13-1543-4eae-ba44-59c5761e4d75)
 
 If you see the above, take note of the UUID and move on to flashing Klipper to the toolhead board.
-
 
 # Installing Klipper
 
@@ -108,29 +111,27 @@ Then go into the klipper configuration menu by running:
 
 You want the Processor and Clock Reference to be set as per whatever board you are running. Set Communication interface to 'CAN bus' with the pins that are specific to your toolhead board. Also set the CAN bus speed to the same as the speed in your can0 file. In this guide it is set to 1000000.
 
-**NOTE: The Bootloader offset will be determined by if you are using a bootloader or not. If you are using CanBOOT then set the bootloader offset to the same you sset it when building the CanBOOT firmware. If you are going to run without a bootloader then set the bootloader offset to "No Bootloader"**
+**NOTE: The Bootloader offset will be determined by if you are using a bootloader or not. If you are using Katapult then set the bootloader offset to the same you sset it when building the Katapult firmware. If you are going to run without a bootloader then set the bootloader offset to "No Bootloader"**
 
 Once you have the firmware configured, run a `make clean` to make sure there are no old files hanging around, then `make` to compile the firmware. It will save the firmware to ~/klipper/out/klipper.bin
 
+## If you have Katapult installed
 
-## If you have CanBOOT installed
-
-Run a `python3 ~/CanBoot/scripts/flash_can.py -i can0 -q` and take note of the CanBoot device that it shows:
+Run a `python3 ~/katapult/scripts/flash_can.py -i can0 -q` and take note of the Katapult device that it shows:
 
 ![image](https://user-images.githubusercontent.com/124253477/221345166-bd920eef-8ce9-48ff-9f31-8ebe8da48225.png)
 
-Then run the following command to install klipper firmware via CanBOOT. Use the UUID you just retrieved in the above query.
+Then run the following command to install klipper firmware via Katapult. Use the UUID you just retrieved in the above query.
 
-`python3 ~/CanBoot/scripts/flash_can.py -i can0 -u b6d9de35f24f -f ~/klipper/out/klipper.bin`
+`python3 ~/katapult/scripts/flash_can.py -i can0 -u b6d9de35f24f -f ~/klipper/out/klipper.bin`
 
 where the "-u" ID is what you found from the "flash_can.py -i can0 -q" query.
 
-One the flash has been completed you can run the `python3 ~/CanBoot/scripts/flash_can.py -i can0 -q` command again. This time you should see the same UUID but with "Application: Klipper" instead of "Application: CanBoot"
+One the flash has been completed you can run the `python3 ~/katapult/scripts/flash_can.py -i can0 -q` command again. This time you should see the same UUID but with "Application: Klipper" instead of "Application: Katapult"
 
 ![image](https://user-images.githubusercontent.com/124253477/221346236-5633f522-97b6-43e7-a675-82f3e483e3a4.png)
 
-
-## If you don't have CanBOOT installed
+## If you don't have Katapult installed
 
 To flash, connect your toolhead board to the Pi via USB and put it into DFU/BOOT mode (your toolhead board user manual should have instructions on doing this).
 
@@ -150,9 +151,8 @@ To confirm it's in BOOT mode, run an `lsusb` command and you should see the devi
 
 > Note the address of the usb device => 2e8a:0003
 
-
-
 Then simply run the following commands to change to the klipper directory then flash the toolhead board.
+
 ```
 cd ~/klipper
 make flash FLASH_DEVICE=0483:df11
@@ -170,83 +170,64 @@ You can now run the Klipper canbus query to retrieve the canbus_uuid of your too
 
 Use this UUID in the [mcu] section of your printer.cfg in order for Klipper (on Pi) to connect to the toolhead board.
 
-
 # UPDATING
 
-If you are planning on updating both CanBOOT and Klipper (ie. for changing CAN speeds) then it's recommended to update CanBOOT first. Otherwise you may get stuck in a situation where you need to connect your toolhead back up via USB and flash as if from scratch.
+If you are planning on updating both Katapult and Klipper (ie. for changing CAN speeds) then it's recommended to update Katapult first. Otherwise you may get stuck in a situation where you need to connect your toolhead back up via USB and flash as if from scratch.
 
-## Updating CanBOOT
+## Updating Katapult
 
-Change to your CanBoot directory with `cd ~/CanBoot`  
-then go into the CanBoot firmware config menu with `make menuconfig`  
-This time **make sure "Build CanBoot deployment application" is configured** with the properly bootloader offset (same as the "Application start offset" that is relevant for your toolhead). Make sure all the rest of your settings are correct for your toolhead.
+Change to your Katapult directory with `cd ~/katapult`
+then go into the Katapult firmware config menu with `make menuconfig`
+This time **make sure "Build Katapult deployment application" is configured** with the properly bootloader offset (same as the "Application start offset" that is relevant for your toolhead). Make sure all the rest of your settings are correct for your toolhead.
 
 ![image](https://user-images.githubusercontent.com/124253477/223301620-c1fd3d16-04e3-49ce-8d48-5498811f4c46.png)
 
-This time when you run `make`, along with the normal canboot.bin file it will also generate a deployer.bin file. This deployer.bin is a fancy little tool that uses the existing bootloader (canboot, or stock, or whatever) to "update" itself into the canboot you just compiled.
+This time when you run `make`, along with the normal katapult.bin file it will also generate a deployer.bin file. This deployer.bin is a fancy little tool that uses the existing bootloader (Katapult, or stock, or whatever) to "update" itself into the Katapult you just compiled.
 
-So to update your canboot, you just need to flash this deployer.bin file via your existing canboot (in a very similar way you would flash klipper via canboot).
+So to update your Katapult, you just need to flash this deployer.bin file via your existing Katapult (in a very similar way you would flash klipper via Katapult).
 
-If you already have a functioning CAN setup, and your [mcu toolhead] canbus_uuid is in your printer.cfg, then you can force CanBOOT to reboot into canboot mode by running:
+If you already have a functioning CAN setup, and your [mcu toolhead] canbus_uuid is in your printer.cfg, then you can force Katapult to reboot into Katapult mode by running:
 
-`python3 ~/CanBoot/scripts/flash_can.py -i can0 -u yourtoolheaduuid -r`
+`python3 ~/katapult/scripts/flash_can.py -i can0 -u yourtoolheaduuid -r`
 
 ![image](https://user-images.githubusercontent.com/124253477/223307559-1da6a2dd-d572-456c-9ee6-0565e9192fea.png)
 
-If you don't have the UUID (or something has gone wrong with the klipper firmware and your toolboard is hung) then you can also double-press the RESET button on your toolhead to force CanBOOT to reboot into canboot mode.
+If you don't have the UUID (or something has gone wrong with the klipper firmware and your toolboard is hung) then you can also double-press the RESET button on your toolhead to force Katapult to reboot into Katapult mode.
 
-You can verify it is in the proper mode by running `python3 ~/CanBoot/scripts/flash_can.py -q`. If you see a "Detected UUID: xxxxxxxxx, Application: CanBoot" device then it is good to go.
+You can verify it is in the proper mode by running `python3 ~/katapult/scripts/flash_can.py -q`. If you see a "Detected UUID: xxxxxxxxx, Application: Katapult" device then it is good to go.
 
 ![image](https://user-images.githubusercontent.com/124253477/223307593-b96dc642-9fa0-494b-93b8-a155d14bb535.png)
 
 Once you are at this stage you can flash the deployer.bin by running:
 
-`python3 ~/CanBoot/scripts/flash_can.py -i can0 -u b6d9de35f24f -f ~/CanBoot/out/deployer.bin`
+`python3 ~/katapult/scripts/flash_can.py -i can0 -u b6d9de35f24f -f ~/katapult/out/deployer.bin`
 
-and your CanBoot should update.
+and your Katapult should update.
 
+## Updating Klipper Firmware via Katapult
 
-## Updating Klipper Firmware via CanBOOT
+To update Klipper, first compile the new Klipper firmware by running the same way you did in the "Installing Klipper" section above, but with your new settings (if you are changing settings). Then you need to get Katapult back into Katapult mode.
 
-To update Klipper, first compile the new Klipper firmware by running the same way you did in the "Installing Klipper" section above, but with your new settings (if you are changing settings). Then you need to get CanBOOT back into canboot mode.
+If you already have a functioning CAN setup, and your [mcu toolhead] canbus_uuid is in your printer.cfg, then you can force Katapult to reboot into Katapult mode by running:
 
-If you already have a functioning CAN setup, and your [mcu toolhead] canbus_uuid is in your printer.cfg, then you can force CanBOOT to reboot into canboot mode by running:
-
-`python3 ~/CanBoot/scripts/flash_can.py -i can0 -u yourtoolheaduuid -r`
+`python3 ~/katapult/scripts/flash_can.py -i can0 -u yourtoolheaduuid -r`
 
 ![image](https://user-images.githubusercontent.com/124253477/223307559-1da6a2dd-d572-456c-9ee6-0565e9192fea.png)
 
-If you don't have the UUID (or something has gone wrong with the klipper firmware and your toolboard is hung) then you can also double-press the RESET button on your toolhead to force CanBOOT to reboot into canboot mode.
+If you don't have the UUID (or something has gone wrong with the klipper firmware and your toolboard is hung) then you can also double-press the RESET button on your toolhead to force Katapult to reboot into Katapult mode.
 
-You can verify it is in the proper mode by running `python3 ~/CanBoot/scripts/flash_can.py -q`. If you see a "Detected UUID: xxxxxxxxx, Application: CanBoot" device then it is good to go.
+You can verify it is in the proper mode by running `python3 ~/katapult/scripts/flash_can.py -q`. If you see a "Detected UUID: xxxxxxxxx, Application: Katapult" device then it is good to go.
 
 ![image](https://user-images.githubusercontent.com/124253477/223307593-b96dc642-9fa0-494b-93b8-a155d14bb535.png)
 
 Then you can run the same command you used to initially flash Klipper:
 
-`python3 ~/CanBoot/scripts/flash_can.py -i can0 -u b6d9de35f24f -f ~/klipper/out/klipper.bin`
+`python3 ~/katapult/scripts/flash_can.py -i can0 -u b6d9de35f24f -f ~/klipper/out/klipper.bin`
 
-One the flash has been completed you can run the `python3 ~/CanBoot/scripts/flash_can.py -i can0 -q` command again. This time you should see the same UUID but with "Application: Klipper" instead of "Application: CanBoot"
+One the flash has been completed you can run the `python3 ~/katapult/scripts/flash_can.py -i can0 -q` command again. This time you should see the same UUID but with "Application: Klipper" instead of "Application: Katapult"
 
 ![image](https://user-images.githubusercontent.com/124253477/221346236-5633f522-97b6-43e7-a675-82f3e483e3a4.png)
 
-
 ## Updating Klipper Firmware via other methods
 
-If you don't use CanBOOT, then updating klipper is the same process as a first-time flash as outlined in the above "If you don't have CanBOOT installed" section.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+If you don't use Katapult, then updating klipper is the same process as a first-time flash as outlined in the above "If you don't have Katapult installed" section.

--- a/toolhead_flashing/common_hardware/BigTreeTech EBB36 V1.2/README.md
+++ b/toolhead_flashing/common_hardware/BigTreeTech EBB36 V1.2/README.md
@@ -11,17 +11,17 @@
     Bus 001 Device 005: ID 0483:df11 STMicroelectronics STM Device in DFU Mode
     ```
 
-# CanBOOT Config
+# Katapult Config
 
 ![image](https://user-images.githubusercontent.com/124253477/228764838-d75c7bc4-a27f-4c3a-b6c8-ef0e78f49f4f.png)
 
 
-# Klipper when using CanBOOT
+# Klipper when using Katapult
 
 ![image](https://user-images.githubusercontent.com/124253477/221349102-cd2f4060-9c29-44aa-b722-9883262b2fc3.png)
 
 
-# Klipper when **NOT** using CanBOOT
+# Klipper when **NOT** using Katapult
 
 ![image](https://user-images.githubusercontent.com/124253477/221349111-570dedac-fa9b-4706-b0d3-3bbc773461f0.png)
 

--- a/toolhead_flashing/common_hardware/BigTreeTech EBB42 V1.2/README.md
+++ b/toolhead_flashing/common_hardware/BigTreeTech EBB42 V1.2/README.md
@@ -11,17 +11,17 @@
     Bus 001 Device 005: ID 0483:df11 STMicroelectronics STM Device in DFU Mode
     ```
 
-# CanBOOT Config
+# Katapult Config
 
 ![image](https://user-images.githubusercontent.com/124253477/228764838-d75c7bc4-a27f-4c3a-b6c8-ef0e78f49f4f.png)
 
 
-# Klipper when using CanBOOT
+# Klipper when using Katapult
 
 ![image](https://user-images.githubusercontent.com/124253477/221349102-cd2f4060-9c29-44aa-b722-9883262b2fc3.png)
 
 
-# Klipper when **NOT** using CanBOOT
+# Klipper when **NOT** using Katapult
 
 ![image](https://user-images.githubusercontent.com/124253477/221349111-570dedac-fa9b-4706-b0d3-3bbc773461f0.png)
 

--- a/toolhead_flashing/common_hardware/BigTreeTech SB2209 and SB2240/README.md
+++ b/toolhead_flashing/common_hardware/BigTreeTech SB2209 and SB2240/README.md
@@ -12,17 +12,17 @@
     Bus 001 Device 005: ID 0483:df11 STMicroelectronics STM Device in DFU Mode
     ```
 
-# CanBOOT Config
+# Katapult Config
 
 ![image](https://user-images.githubusercontent.com/124253477/228764307-36da2c3a-393d-43d9-b370-4eb31d231c27.png)
 
 
-# Klipper when using CanBOOT
+# Klipper when using Katapult
 
 ![image](https://user-images.githubusercontent.com/124253477/221349102-cd2f4060-9c29-44aa-b722-9883262b2fc3.png)
 
 
-# Klipper when **NOT** using CanBOOT
+# Klipper when **NOT** using Katapult
 
 ![image](https://user-images.githubusercontent.com/124253477/221349111-570dedac-fa9b-4706-b0d3-3bbc773461f0.png)
 

--- a/toolhead_flashing/common_hardware/Mellow Fly ERCF/README.md
+++ b/toolhead_flashing/common_hardware/Mellow Fly ERCF/README.md
@@ -1,6 +1,6 @@
 # BOOT Mode
 
-To put the ERCF into boot mode (for initial flashing), unplug any USB and CAN cables from the ERCF, then hold the BOOT button. While continuing to hold the BOOT button plug in the USB cable from the Pi to the ERCF. Keep holding the BOOT button for a few more second, then release. 
+To put the ERCF into boot mode (for initial flashing), unplug any USB and CAN cables from the ERCF, then hold the BOOT button. While continuing to hold the BOOT button plug in the USB cable from the Pi to the ERCF. Keep holding the BOOT button for a few more second, then release.
 
 ![image](img/dfu-mode.png)
 
@@ -9,16 +9,16 @@ The ERCF should now show up to an `lsusb` command as Pi RP2 Boot device:
 ![image](https://user-images.githubusercontent.com/124253477/226155004-2cc63e48-4545-46c0-92ed-b09cd26c8e80.png)
 
 
-# CanBOOT Config
+# Katapult Config
 
 ![image](./img/canboot.png)
 
-# Klipper when using CanBOOT
+# Klipper when using Katapult
 
 ![image](./img/klipper-canboot.png)
 
 
-# Klipper when **NOT** using CanBOOT
+# Klipper when **NOT** using Katapult
 
 ![image](./img/klipper-only.png)
 

--- a/toolhead_flashing/common_hardware/Mellow Fly SB2040/README.md
+++ b/toolhead_flashing/common_hardware/Mellow Fly SB2040/README.md
@@ -5,16 +5,16 @@ To put the SB2040 into boot mode (for initial flashing), unplug any USB and CAN 
 ![image](https://user-images.githubusercontent.com/124253477/226155004-2cc63e48-4545-46c0-92ed-b09cd26c8e80.png)
 
 
-# CanBOOT Config
+# Katapult Config
 
 ![image](https://user-images.githubusercontent.com/124253477/228765757-5a8bab71-6f57-4467-8400-4bbb9d37e2f6.png)
 
-# Klipper when using CanBOOT
+# Klipper when using Katapult
 
 ![image](https://user-images.githubusercontent.com/124253477/221348650-b9f2749e-0f3b-44b4-b34a-a57bd8beb706.png)
 
 
-# Klipper when **NOT** using CanBOOT
+# Klipper when **NOT** using Katapult
 
 ![image](https://user-images.githubusercontent.com/124253477/221348953-de98e788-734d-4e34-b9dd-1b2a0e99607c.png)
 

--- a/toolhead_flashing/common_hardware/Mellow Fly SHT36 and SHT42/README.md
+++ b/toolhead_flashing/common_hardware/Mellow Fly SHT36 and SHT42/README.md
@@ -1,13 +1,13 @@
 
-# CanBOOT Config
+# Katapult Config
 
 ![image](https://user-images.githubusercontent.com/124253477/228767194-0ee2d789-13b2-44f4-99aa-f0a7f750c99c.png)
 
-# Klipper when using CanBOOT
+# Klipper when using Katapult
 
 ![image](https://user-images.githubusercontent.com/124253477/221396323-83dd84e5-b661-4472-8074-ea45aa19dced.png)
 
-# Klipper when **NOT** using CanBOOT
+# Klipper when **NOT** using Katapult
 
 ![image](https://user-images.githubusercontent.com/124253477/221396331-f32caaac-89a2-4d85-8b88-259681912662.png)
 

--- a/toolhead_flashing/common_hardware/Mellow Fly SHT36v2/README.md
+++ b/toolhead_flashing/common_hardware/Mellow Fly SHT36v2/README.md
@@ -1,15 +1,15 @@
 *Note, SHT-36 V2 units shipped before 2022-10-18 will use the GD32F103 CPU, later shipments will use the APM32F072 CPU. The settings are exactly the same except for the processor model. Make sure the chosen processor model STM32F072 or STM32F103 matches with your board*
 
 
-# CanBOOT Config
+# Katapult Config
 
 ![image](https://user-images.githubusercontent.com/124253477/228767706-e14d572a-b0de-4445-9c7c-11276fc8c4a7.png)
 
-# Klipper when using CanBOOT
+# Klipper when using Katapult
 
 ![image](https://user-images.githubusercontent.com/124253477/221396540-52695957-90f7-4f01-9d7d-130a76a81ee8.png)
 
-# Klipper when **NOT** using CanBOOT
+# Klipper when **NOT** using Katapult
 
 ![image](https://user-images.githubusercontent.com/124253477/221396552-1c495fc2-30be-4bdd-9ac3-430da804bf17.png)
 

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -4,10 +4,9 @@ So, you've followed the instructions but things just aren't working they way the
 
 There won't be any particular order to the sections. Maybe I'll make it flow better in the future, maybe not.
 
-
 ## No CAN network when running a query or flash attempt
 
-If you run a `python3 ~/CanBoot/scripts/flash_can.py -i can0 -q` or `~/klippy-env/bin/python ~/klipper/scripts/canbus_query.py can0` or are trying to flash a device with a command like `python3 ~/CanBoot/scripts/flash_can.py -i can0 -u b6d9de35f24f -f ~/klipper/out/klipper.bin` but you are seeing an error along the lines of "unable to bind socket to can0" or "failed to transmit, network is down" then your can0 "interface" on your Pi isn't running.
+If you run a `python3 ~/katapult/scripts/flash_can.py -i can0 -q` or `~/klippy-env/bin/python ~/klipper/scripts/canbus_query.py can0` or are trying to flash a device with a command like `python3 ~/katapult/scripts/flash_can.py -i can0 -u b6d9de35f24f -f ~/klipper/out/klipper.bin` but you are seeing an error along the lines of "unable to bind socket to can0" or "failed to transmit, network is down" then your can0 "interface" on your Pi isn't running.
 
 ![image](https://user-images.githubusercontent.com/124253477/235117239-009ab013-d9ba-4524-81d4-a73c8990c2a7.png)
 
@@ -15,13 +14,13 @@ First thing to check is your `/etc/network/interfaces.d/can0` file. Make sure it
 
 ### Seperate USB-CAN adapter (U2C/UTOC/etc.)
 
-If you are using a seprate USB to CAN adapter (U2C/UTOC/etc.) then double check that the USB cable connecting the devices is plugged in and not loose. If you *never* get a response to a query (ie. the can0 interface has never shown at all) then you may have a dodgy USB cable. I have personally seen a handful of usb-c cables that don't actually have the data pins hooked up (they are power only). If the adapter doesn't show to an `lsusb` then your cable is probably dodgy.
+If you are using a seprate USB to CAN adapter (U2C/UTOC/etc.) then double check that the USB cable connecting the devices is plugged in and not loose. If you _never_ get a response to a query (ie. the can0 interface has never shown at all) then you may have a dodgy USB cable. I have personally seen a handful of usb-c cables that don't actually have the data pins hooked up (they are power only). If the adapter doesn't show to an `lsusb` then your cable is probably dodgy.
 
 If it shows up to an `lsusb` but an `ip link show can0` shows "Device can0 does not exist" then you might have a bad firmware or something on your device. Reflash it with the appropriate firmware either from a manufacturer github repository or other source (like candlelight). If there are instructions back on the voron_canbus/can_adapter folder then follow those.
 
 ### USB-CAN-Bridge mode mainboard
 
-Check that the Pi-to-mainboard USB cable hasn't come loose or anything, and that the mainboard is actually powered up. An `lsusb` should show the mainboard up as a can adapter device. If it's not showing as a can adapter device then do an `ls /dev/serial/by-id`. If you see your mainboard there then either it's still in CanBoot mode, or you haven't flashed usb-can-bridge klipper to it (or the flash didn't take). If that is the case then reflash your mainboard as per the voron_canbus/mainboard_flashing instructions and take extra care that the klipper `make menuconfig` settings are 100% correct for your board.
+Check that the Pi-to-mainboard USB cable hasn't come loose or anything, and that the mainboard is actually powered up. An `lsusb` should show the mainboard up as a can adapter device. If it's not showing as a can adapter device then do an `ls /dev/serial/by-id`. If you see your mainboard there then either it's still in Katapult mode, or you haven't flashed usb-can-bridge klipper to it (or the flash didn't take). If that is the case then reflash your mainboard as per the voron_canbus/mainboard_flashing instructions and take extra care that the klipper `make menuconfig` settings are 100% correct for your board.
 
 ## No UUIDs show up to a query
 
@@ -29,17 +28,14 @@ So you're can0 interface is online, but a query returns nothing:
 
 ![image](https://user-images.githubusercontent.com/124253477/235122048-e39c4fb0-6163-4469-b1fa-aa9dddfe69b2.png)
 
-First up, if you previously *could* see UUID's returned, and then put them into your printer.cfg file, but now you can't see anything from a canbus query **don't panic**. Once a UUID has been "grabbed" by klipper-on-pi then it won't show up to a query. This is normal.
+First up, if you previously _could_ see UUID's returned, and then put them into your printer.cfg file, but now you can't see anything from a canbus query **don't panic**. Once a UUID has been "grabbed" by klipper-on-pi then it won't show up to a query. This is normal.
 
-If you haven't put the UUID into your printer.cfg then this means that your method of CAN adapting (standalone adapter or usb-can-bridge mainboard) is running OK but can't see anything on the network. Starting at the adapter end, if you are using a usb-can-bridge mainboard then **double check** that the klipper firmware you flashed had the correct pins set for the CAN network. If you used the wrong pins then the mainboard will boot fine, and even show the can0 interface fine, but will be looking on the wrong pins for CAN traffic and so will never find any other nodes. Note that you should never be able to get into a situation with a usb-can-bridge mainboard where it shows the can0 interface fine but can't find at least its own UUID to a query. 
+If you haven't put the UUID into your printer.cfg then this means that your method of CAN adapting (standalone adapter or usb-can-bridge mainboard) is running OK but can't see anything on the network. Starting at the adapter end, if you are using a usb-can-bridge mainboard then **double check** that the klipper firmware you flashed had the correct pins set for the CAN network. If you used the wrong pins then the mainboard will boot fine, and even show the can0 interface fine, but will be looking on the wrong pins for CAN traffic and so will never find any other nodes. Note that you should never be able to get into a situation with a usb-can-bridge mainboard where it shows the can0 interface fine but can't find at least its own UUID to a query.
 
-Next, check the firmware of your toolhead. If you never saw the toolhead canboot or klipper as a UUID at all then **double check** the canboot/klipper firmware for incorrect settings. This could be any setting as even a single incorrect setting on this firmware will either stop the toolhead from booting at all (in which case you won't see it on the network) or it boots but is looking at the wrong CAN pins/has the wrong CAN speed (in which case you also won't see it on the network).
+Next, check the firmware of your toolhead. If you never saw the toolhead Katapult or klipper as a UUID at all then **double check** the Katapult/klipper firmware for incorrect settings. This could be any setting as even a single incorrect setting on this firmware will either stop the toolhead from booting at all (in which case you won't see it on the network) or it boots but is looking at the wrong CAN pins/has the wrong CAN speed (in which case you also won't see it on the network).
 
-I'm going to assume you are using CanBoot from this point on. If this had the correct settings (which you have double checked) and it flashed OK then we can assume it has booted into Canboot. I would recommend setting a status_led pin in the config (I have outlined the correct pins to use for this in the toolhead_flashing/common_hardware entries) as it will be flashing an LED if it is sitting in CanBoot mode.
+I'm going to assume you are using Katapult from this point on. If this had the correct settings (which you have double checked) and it flashed OK then we can assume it has booted into Katapult. I would recommend setting a status_led pin in the config (I have outlined the correct pins to use for this in the toolhead_flashing/common_hardware entries) as it will be flashing an LED if it is sitting in Katapult mode.
 
-If it's sitting in CanBoot but you still can't see a UUID then your problem is likely down to wiring. Check that you have the 120ohm resistor/jumper in at both ends (some mainboards like the Octopus have the resistor prebuilt, no jumper needed). If you hook the CAN wires up, then use a multimeter in resistance mode and measure across the CanH and CanL wires at **one** end (eg. at the maibnoard/adapter end) you should see a resistance of around 60 ohms. This is because you will have two 120ohm resistors in parallel, and this ends up being 60 ohms of resistance (parallel resistor values are a bit weird like that, google it if you don't belive me).
+If it's sitting in Katapult but you still can't see a UUID then your problem is likely down to wiring. Check that you have the 120ohm resistor/jumper in at both ends (some mainboards like the Octopus have the resistor prebuilt, no jumper needed). If you hook the CAN wires up, then use a multimeter in resistance mode and measure across the CanH and CanL wires at **one** end (eg. at the maibnoard/adapter end) you should see a resistance of around 60 ohms. This is because you will have two 120ohm resistors in parallel, and this ends up being 60 ohms of resistance (parallel resistor values are a bit weird like that, google it if you don't belive me).
 
-If you see the 60ohms then you know both resistors are in circuit and also your wires are connected (no breaks). If still no UUID then swap your CanH and CanL wires around as this is a *very* common mistake to make.
-
-
-
+If you see the 60ohms then you know both resistors are in circuit and also your wires are connected (no breaks). If still no UUID then swap your CanH and CanL wires around as this is a _very_ common mistake to make.

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -6,7 +6,7 @@ There won't be any particular order to the sections. Maybe I'll make it flow bet
 
 ## No CAN network when running a query or flash attempt
 
-If you run a `python3 ~/katapult/scripts/flash_can.py -i can0 -q` or `~/klippy-env/bin/python ~/klipper/scripts/canbus_query.py can0` or are trying to flash a device with a command like `python3 ~/katapult/scripts/flash_can.py -i can0 -u b6d9de35f24f -f ~/klipper/out/klipper.bin` but you are seeing an error along the lines of "unable to bind socket to can0" or "failed to transmit, network is down" then your can0 "interface" on your Pi isn't running.
+If you run a `python3 ~/katapult/scripts/flashtool.py -i can0 -q` or `~/klippy-env/bin/python ~/klipper/scripts/canbus_query.py can0` or are trying to flash a device with a command like `python3 ~/katapult/scripts/flashtool.py -i can0 -u b6d9de35f24f -f ~/klipper/out/klipper.bin` but you are seeing an error along the lines of "unable to bind socket to can0" or "failed to transmit, network is down" then your can0 "interface" on your Pi isn't running.
 
 ![image](https://user-images.githubusercontent.com/124253477/235117239-009ab013-d9ba-4524-81d4-a73c8990c2a7.png)
 

--- a/troubleshooting/debugging/can_debug.sh
+++ b/troubleshooting/debugging/can_debug.sh
@@ -16,11 +16,11 @@ KERNEL="$(uname -a)"
 IPA="$(ip a)"
 CANSTATS="$(ip -details -statistics link show can0)"
 LSUSB="$(lsusb)"
-BITVERSION="$(getconf LONG_BIT)" 
+BITVERSION="$(getconf LONG_BIT)"
 CANQUERY="$(~/klippy-env/bin/python ~/klipper/scripts/canbus_query.py can0)"
 
 # Identification of directories pertainent to CAN fw compilation files.
-CANBOOTDIR="/home/$USER/CanBoot/"
+KATAPULTDIR="/home/$USER/katapult/"
 CANFND="NOT Found"
 
 KLIPPERDIR="/home/$USER/klipper/"
@@ -38,17 +38,17 @@ else
 fi
 
 # Retrieving bootloader compilation configuration.
-if [ -d ${CANBOOTDIR} ]; then
-    if [ -f ${CANBOOTDIR}/.config ]; then 
-        CANFND="Found\n\nCanBoot Config:\n$(cat ${CANBOOTDIR}/.config)"
+if [ -d ${KATAPULTDIR} ]; then
+    if [ -f ${KATAPULTDIR}/.config ]; then
+        CANFND="Found\n\nKatapult Config:\n$(cat ${KATAPULTDIR}/.config)"
     else
-        CANFND="Found\n\nCanBoot Make Config: Not Found"
+        CANFND="Found\n\nKatapult Make Config: Not Found"
     fi
 fi
 
 # Retrieving klipper firmware compilation configuration.
 if [ -d ${KLIPPERDIR} ]; then
-    if [ -f ${KLIPPERDIR}/.config ]; then 
+    if [ -f ${KLIPPERDIR}/.config ]; then
         KLIPPERFND="Found\n\nKlipper Config:\n$(cat ${KLIPPERDIR}/.config)"
     else
         KLIPPERFND="Found\n\nKlipper Make Config: Not Found"
@@ -57,9 +57,9 @@ fi
 
 # Retrieving mcu info from klippy log
 if [ -d ${PRNTDATA} ]; then
-    if [ -f ${PRNTDATA}/klippy.log ]; then 
+    if [ -f ${PRNTDATA}/klippy.log ]; then
         PRNTDATAFND="Found\n\nKlippy Log:\n$(grep "MCU 'mcu' config" ~/printer_data/logs/klippy.log | tail -1)"
-        KLIPPERCFG="$(tac ~/printer_data/logs/klippy.log | awk '/=======================/&&++k==1,/===== Config file =====/' | tac)" 
+        KLIPPERCFG="$(tac ~/printer_data/logs/klippy.log | awk '/=======================/&&++k==1,/===== Config file =====/' | tac)"
     else
         PRNTDATAFND="Found\n\nKlippy Log: Not Found"
         KLIPPERCFG="Found\n\nKlippy Log: Not Found"
@@ -71,7 +71,7 @@ TXT_NET="\n\n${PRETTY_LINE_BRK}\nNetwork\n${PRETTY_LINE_BRK}\n\ncan0:\n${NETWORK
 TXT_USB="\n\n${PRETTY_LINE_BRK}\nUSB\n${PRETTY_LINE_BRK}\n\nlsusb:\n${LSUSB}"
 TXT_CANQ="\n\n${PRETTY_LINE_BRK}\nCANQuery\n${PRETTY_LINE_BRK}\n\nCANBus Query:\n${CANQUERY}"
 TXT_LOG="\n\n${PRETTY_LINE_BRK}\nMCU\n${PRETTY_LINE_BRK}\n\nMCUInfo:\n${PRNTDATAFND}"
-TXT_CAN="\n\n${PRETTY_LINE_BRK}\nCanBoot\n${PRETTY_LINE_BRK}\n\nCanBoot Directory: ${CANFND}"
+TXT_CAN="\n\n${PRETTY_LINE_BRK}\nKatapult\n${PRETTY_LINE_BRK}\n\nKatapult Directory: ${CANFND}"
 TXT_KLP="\n\n${PRETTY_LINE_BRK}\nKlipper\n${PRETTY_LINE_BRK}\n\nKlipper Directory: ${KLIPPERFND}"
 TXT_CFG="\n\n${PRETTY_LINE_BRK}\nKlipperConfig\n${PRETTY_LINE_BRK}\n\n${KLIPPERCFG}"
 


### PR DESCRIPTION
Rename CanBoot across the repo to deal with the name-change to Katapult.

Even though legacy references have been added to the Katapult repo, it is still best to start dealing with the appropriate names going forward.

Note: Screenshots have not been updated.