### PR TITLE
QOL changes to instructions

### DIFF
--- a/Dedicated_USB_Can_Device.md
+++ b/Dedicated_USB_Can_Device.md
@@ -9,6 +9,9 @@ nav_order: 30
 # Dedicated USB CAN device
 
 If you want to use a dedicated USB CAN devcice, then it should be as  simple as plugging it in to your Pi via USB. ***You shouldn't have to flash anything to this U2C/UTOC/etc device first, they are meant to come pre-installed with the necessary firmware. They do NOT run Klipper***. You can test if it is working by running an `lsusb` command (from an SSH terminal to your pi). Most common USB CAN devices will show up as a "Geschwister Schneider CAN adapter" when they are working properly (though some may simply show as an "OpenMoko, Inc" device):
+```bash
+lsusb
+```
 
 ![image](https://user-images.githubusercontent.com/124253477/221329262-d8758abd-62cb-4bb6-9b4f-7bc0f615b5de.png)
 
@@ -16,6 +19,9 @@ If you want to use a dedicated USB CAN devcice, then it should be as  simple as 
 
 
 A better check is by running `ip -s -d link show can0` . If everything is correct you will see something like this:
+```bash
+ip -s -d link show can0
+```
 
 ![image](https://github.com/user-attachments/assets/f9366698-d1f8-44ed-8f8b-33c5b924dc37)
 

--- a/katapult_updating.md
+++ b/katapult_updating.md
@@ -18,8 +18,14 @@ This is only if you need to update katapult as well. If you are just doing a Kli
 
 **Step 1**
 
-Change to your Katapult directory with `cd ~/katapult`
-then go into the Katapult firmware config menu with `make menuconfig`
+Change to your Katapult directory with this command:
+```bash
+cd ~/katapult
+```
+then go into the Katapult firmware config menu by running:
+```bash 
+make menuconfig
+```
 This time **make sure "Build Katapult deployment application" is configured** with the properly bootloader offset (same as the "Application start offset" that is relevant for your toolhead). Make sure all the rest of your settings are correct for your toolhead.
 
 You can find screenshots of settings for common toolheads in the [Common Toolhead Hardware](./toolhead_flashing/common_hardware) section, but once again, **make sure "Build Katapult deployment application" is set**
@@ -28,6 +34,10 @@ You can find screenshots of settings for common toolheads in the [Common Toolhea
 
 
 This time when you run `make`, along with the normal katapult.bin file it will also generate a deployer.bin file. This deployer.bin is a fancy little tool that uses the existing bootloader (Katapult, or stock, or whatever) to "update" itself into the Katapult you just compiled.
+```bash
+make clean
+make menuconfig
+```
 
 So to update your Katapult, you just need to flash this deployer.bin file via your existing Katapult (in a very similar way you would flash klipper via Katapult).
 
@@ -36,18 +46,22 @@ So to update your Katapult, you just need to flash this deployer.bin file via yo
 If you already have a functioning CAN setup, and your [mcu toolhead] canbus_uuid is in your printer.cfg, then you can force Katapult to reboot into Katapult mode by running:
 
 ```bash
-python3 ~/katapult/scripts/flashtool.py -i can0 -u yourtoolheaduuid -r
+python3 ~/katapult/scripts/flashtool.py -i can0 -r -u yourtoolheaduuid
 ```
 
 ![image](https://github.com/Esoterical/voron_canbus/assets/124253477/eda51419-6ab4-49c5-9c33-a581b08d085c)
 
-If will probably say "Flash success" **THIS IS NOT ACTUALLY FLASHING ANYTHING, YOU NEED TO CONTINUE WITH THE STEPS BELOW**
+If will probably say "Flash success" 
+**THIS IS NOT ACTUALLY FLASHING ANYTHING, YOU NEED TO CONTINUE WITH THE STEPS BELOW**
 
 **Step 3**
 
 If you don't have the UUID (or something has gone wrong with the klipper firmware and your toolboard is hung) then you can also double-press the RESET button on your toolhead to force Katapult to reboot into Katapult mode.
 
 You can verify it is in the proper mode by running `python3 ~/katapult/scripts/flashtool.py -q`. If you see a "Detected UUID: xxxxxxxxx, Application: Katapult" device then it is good to go.
+```bash
+python3 ~/katapult/scripts/flashtool.py -q
+```
 
 ![image](https://github.com/Esoterical/voron_canbus/assets/124253477/ff9dcbb3-0456-4d87-8091-41d5d6050c02)
 
@@ -69,8 +83,14 @@ However, **if** you need to update katapult for whatever reason then follow the 
 
 **Step 1**
 
-Change to your Katapult directory with `cd ~/katapult`
-then go into the Katapult firmware config menu with `make menuconfig`
+Change to your Katapult directory:
+```bash
+cd ~/katapult
+```
+then go into the Katapult firmware config menu by running:
+```bash
+make menuconfig
+```
 
 This time **make sure "Build Katapult deployment application" is configured** with the properly bootloader offset (same as the "Application start offset" that is relevant for your mainboard). Make sure all the rest of your settings are correct for your mainboard.
 
@@ -81,7 +101,10 @@ If your board doesn't exist in the common_hardware folder already, then you want
 ![image](https://github.com/Esoterical/voron_canbus/assets/124253477/7726b137-0079-4191-bd22-1b084345809f)
 
 This time when you run `make`, along with the normal katapult.bin file it will also generate a deployer.bin file. This deployer.bin is a fancy little tool that uses the existing bootloader (Katapult, or stock, or whatever) to "update" itself into the Katapult you just compiled.
-
+```bash
+make clean
+make menuconfig
+```
 So to update your Katapult, you just need to flash this deployer.bin file via your existing Katapult (in a very similar way you would flash klipper via Katapult).
 
 **Step 2**
@@ -89,7 +112,7 @@ So to update your Katapult, you just need to flash this deployer.bin file via yo
 If you already have a functioning CAN setup, and your [mcu] canbus_uuid is in your printer.cfg, then you can force Katapult to reboot into Katapult mode by running:
 
 ```bash
-python3 ~/katapult/scripts/flashtool.py -i can0 -u yourmainboarduuid -r
+python3 ~/katapult/scripts/flashtool.py -i can0 -r -u yourmainboarduuid
 ```
 
 ![image](https://github.com/Esoterical/voron_canbus/assets/124253477/eda51419-6ab4-49c5-9c33-a581b08d085c)
@@ -101,6 +124,9 @@ If will probably say "Flash success" **THIS IS NOT ACTUALLY FLASHING ANYTHING, Y
 If you don't have the UUID (or something has gone wrong with the klipper firmware and your mainboard is hung) then you can also double-press the RESET button on your mainboard to force Katapult to reboot into Katapult mode.
 
 You can verify it is in the proper mode by running `ls /dev/serial/by-id`. If you see a "usb-katapult-......" device then it is good to go.
+```bash
+ls /dev/serial/by-id
+```
 
 ![image](https://github.com/Esoterical/voron_canbus/assets/124253477/1e9f0f7c-ada3-490b-bd62-bde25b67c362)
 

--- a/katapult_updating.md
+++ b/katapult_updating.md
@@ -18,14 +18,12 @@ This is only if you need to update katapult as well. If you are just doing a Kli
 
 **Step 1**
 
-Change to your Katapult directory with this command:
+Change to your Katapult directory, then go into the Katapult firmware config menu by running::
 ```bash
 cd ~/katapult
-```
-then go into the Katapult firmware config menu by running:
-```bash 
 make menuconfig
 ```
+
 This time **make sure "Build Katapult deployment application" is configured** with the properly bootloader offset (same as the "Application start offset" that is relevant for your toolhead). Make sure all the rest of your settings are correct for your toolhead.
 
 You can find screenshots of settings for common toolheads in the [Common Toolhead Hardware](./toolhead_flashing/common_hardware) section, but once again, **make sure "Build Katapult deployment application" is set**
@@ -36,7 +34,7 @@ You can find screenshots of settings for common toolheads in the [Common Toolhea
 This time when you run `make`, along with the normal katapult.bin file it will also generate a deployer.bin file. This deployer.bin is a fancy little tool that uses the existing bootloader (Katapult, or stock, or whatever) to "update" itself into the Katapult you just compiled.
 ```bash
 make clean
-make menuconfig
+make
 ```
 
 So to update your Katapult, you just need to flash this deployer.bin file via your existing Katapult (in a very similar way you would flash klipper via Katapult).
@@ -103,7 +101,7 @@ If your board doesn't exist in the common_hardware folder already, then you want
 This time when you run `make`, along with the normal katapult.bin file it will also generate a deployer.bin file. This deployer.bin is a fancy little tool that uses the existing bootloader (Katapult, or stock, or whatever) to "update" itself into the Katapult you just compiled.
 ```bash
 make clean
-make menuconfig
+make
 ```
 So to update your Katapult, you just need to flash this deployer.bin file via your existing Katapult (in a very similar way you would flash klipper via Katapult).
 

--- a/mainboard_flashing.md
+++ b/mainboard_flashing.md
@@ -48,6 +48,7 @@ Press Q to quit the menu (it will ask to save, choose yes).
 
 Compile the firmware with `make`. You will now have a katapult.bin at ~/katapult/out/katapult.bin.
 ```bash
+make clean
 make
 ```
 

--- a/mainboard_flashing.md
+++ b/mainboard_flashing.md
@@ -47,6 +47,9 @@ If your board doesn't exist in the common_hardware folder already, then you want
 Press Q to quit the menu (it will ask to save, choose yes).
 
 Compile the firmware with `make`. You will now have a katapult.bin at ~/katapult/out/katapult.bin.
+```bash
+make
+```
 
 To flash, connect your mainboard to the Pi via USB then put the mainboard into DFU/BOOT mode (your mainboard user manual should have instructions on doing this).
 
@@ -57,6 +60,9 @@ If your toolhead board uses an RP2040 MCU, use [these flashing steps](#rp2040-ba
 ## STM32 based boards
 
 To confirm it's in DFU mode you can run the command `lsusb` and look for an entry of "STMicroelectronics STM Device in DFU mode"
+```bash
+lsusb
+```
 
 ![image](https://github.com/user-attachments/assets/cde7138d-588b-4381-82ad-699cde37e0a8)
 
@@ -77,6 +83,9 @@ Katapult is now installed, [click here](#katapult-is-now-installed) for the next
 ## RP2040 based boards
 
 To confirm it's in BOOT mode, run an `lsusb` command and you should see the device as a "Raspberry Pi boot" device (or similar)
+```bash
+lsusb
+```
 
 ![image](https://user-images.githubusercontent.com/124253477/221344712-500b3c36-8e96-4f23-88ed-5e13ee79535f.png)
 
@@ -146,6 +155,10 @@ Again, if your mainboard is already in [Common Mainboard Hardware](./mainboard_f
 Otherwise, you want the Processor and Clock Reference to be set as per whatever board you are running. Set Communication interface to 'USB to CAN bus bridge' then set the CAN Bus interface to use the pins that are specific to your mainboard. Also set the CAN bus speed to the same as the speed in your can0 file. In this guide it is set to 1000000.
 
 Once you have the firmware configured, run a `make clean` to make sure there are no old files hanging around, then `make` to compile the firmware. It will save the firmware to ~/klipper/out/klipper.bin
+```bash
+make clean
+make
+```
 
 ## Using Katapult to flash Klipper
 
@@ -156,6 +169,9 @@ sudo service klipper stop
 ```
 
 Run an `ls /dev/serial/by-id/` and take note of the Katapult device that it shows:
+```bash
+ls /dev/serial/by-id/
+```
 
 ![image](https://github.com/Esoterical/voron_canbus/assets/124253477/f836fa8d-fb26-4ccd-b1e1-50f010596852)
 
@@ -175,6 +191,9 @@ This should have now installed klipper firmware to your mainboard. You can verif
 ![image](https://user-images.githubusercontent.com/124253477/221329262-d8758abd-62cb-4bb6-9b4f-7bc0f615b5de.png)
 
 Check that the can0 interface is up by running `ip -s -d link show can0` . If everything is correct you will see something like this:
+```bash
+ip -s -d link show can0
+```
 
 ![image](https://github.com/user-attachments/assets/c211da71-a0e3-4c47-b4a2-fdef3b717999)
 

--- a/mainboard_klipper_updating.md
+++ b/mainboard_klipper_updating.md
@@ -11,10 +11,11 @@ nav_order: 20
 
 To update Klipper, you first need to compile a new klipper.bin with the correct settings.
 
-Move into the klipper directory on the Pi by running:
-`cd ~/klipper`
-Then go into the klipper configuration menu by running:
-`make menuconfig`
+Move into the klipper directory on the Pi, then go into the klipper configuration menu by running:
+```bash
+cd ~/klipper
+make menuconfig
+```
 
 You can find screenshots of settings for common mainboards in the [Common Mainboard Hardware](./mainboard_flashing/common_hardware) section.
 
@@ -28,12 +29,12 @@ First, stop the Klipper service on the Pi by running:
 
 ```bash
 sudo service klipper stop
-````
+```
 
 If you already have a functioning CAN setup, and your [mcu] canbus_uuid is in your printer.cfg, then you can force Katapult to reboot into Katapult mode by running:
 
 ```bash
-python3 ~/katapult/scripts/flashtool.py -i can0 -u yourmainboarduuid -r
+python3 ~/katapult/scripts/flashtool.py -i can0 -r -u yourmainboarduuid
 ```
 
 ![image](https://github.com/Esoterical/voron_canbus/assets/124253477/eda51419-6ab4-49c5-9c33-a581b08d085c)
@@ -47,6 +48,9 @@ It will probably say "Flash success" **THIS IS NOT ACTUALLY FLASHING ANYTHING, Y
 **Step 3**
 
 You can verify it is in the proper mode by running `ls /dev/serial/by-id/*`. If you see a "usb-katapult-......" device then it is good to go.
+```bash
+ls /dev/serial/by-id/*
+```
 
 ![image](https://github.com/user-attachments/assets/2ed240e4-1347-403f-be18-d55327049708)
 
@@ -65,4 +69,7 @@ python3 ~/katapult/scripts/flashtool.py -f ~/klipper/out/klipper.bin -d /dev/ser
 **If** an `lsusb` doesn't show up your mainboard as a CAN adapter (or if `ip a` doesn't show your can0 network), or if the can0 network shows fine but you can't connect to your tooolhead that was previously working (and that you haven't flashed anything new to yet) then there is a good chance your klipper.bin settings were incorrect. Go back to Step 1 and check *all* the settings in the `make menuconfig` screen then recompile with `make clean` and `make`, and hen double-click the reset button on your toolhead to kick it back to katapult mode then go from Step 3.
 
 However, **if** the `lsusb` and `ip a` show the correct things then your mainboard is now updated, run `sudo service klipper start` to start the klipper service on your Pi again.
+```bash
+sudo service klipper start
+```
 

--- a/toolhead_flashing.md
+++ b/toolhead_flashing.md
@@ -46,6 +46,9 @@ If your board doesn't exist in the common_hardware folder already, then you want
 
 
 Compile the firmware with `make`. You will now have a katapult.bin (or katapult.uf2) in your ~/katapult/out/ directory.
+```bash
+make
+```
 
 To flash, connect your toolhead board to the Pi via USB then put the toolhead board into DFU/BOOT mode (your toolhead board user manual should have instructions on doing this).
 
@@ -56,6 +59,9 @@ If your toolhead board uses an RP2040 MCU, use [these flashing steps](#rp2040-ba
 ## STM32 based boards
 
 To confirm it’s in DFU mode you can run the command lsusb and look for an entry of “STMicroelectronics STM Device in DFU mode”
+```bash
+lsusb
+```
 
 ![image](https://github.com/user-attachments/assets/0c63ba83-08fa-4a59-9a49-5d2cca97eddd)
 
@@ -75,6 +81,9 @@ Katapult is now installed, [click here](#katapult-is-now-installed) for the next
 ## RP2040 based boards
 
 To confirm it's in BOOT mode, run an `lsusb` command and you should see the device as a "Raspberry Pi boot" device (or similar)
+```bash
+lsusb
+```
 
 ![image](https://user-images.githubusercontent.com/124253477/221344712-500b3c36-8e96-4f23-88ed-5e13ee79535f.png)
 
@@ -99,8 +108,10 @@ Katapult is now installed, [click here](#katapult-is-now-installed) for the next
 
 Katapult should now be successfully flashed. 
 
-Shut down your Pi (`sudo shutdown now`) and then power off your entire printer. 
-
+Shut down your Pi (`sudo shutdown now`) and then power off your entire printer.
+```bash
+sudo shutdown now
+```
 Take out any DFU jumpers on your toolhead (if it needed them) and then wire up your toolhead power (24v and gnd) and CAN (CANH/CANL) wires, then power your printer back up.
 
 Run the following command to see if the toolhead board is on the CAN network and waiting in Katapult mode
@@ -173,7 +184,7 @@ python3 ~/katapult/scripts/flashtool.py -i can0 -q
 Then run the following command to install klipper firmware via Katapult. Use the UUID you just retrieved in the above query.
 
 ```bash
-python3 ~/katapult/scripts/flashtool.py -i can0 -u youruuid -f ~/klipper/out/klipper.bin
+python3 ~/katapult/scripts/flashtool.py -i can0 -f ~/klipper/out/klipper.bin -u youruuid
 ```
 
 where the "-u" ID is what you found from the "flashtool.py -i can0 -q" query.

--- a/toolhead_klipper_updating.md
+++ b/toolhead_klipper_updating.md
@@ -25,6 +25,9 @@ You can find screenshots of settings for common toolheads in the [Common Toolhea
 You want the Processor and Clock Reference to be set as per whatever board you are running. Set Communication interface to 'CAN bus' with the pins that are specific to your toolhead board. Also set the CAN bus speed to the same as the speed in your can0 file. In this guide it is set to 1000000.
 
 Once you have the firmware configured, hit Q to save and quit from the makemenu screen, then run a `make clean` to make sure there are no old files hanging around, then `make` to compile the firmware. It will save the firmware to ~/klipper/out/klipper.bin
+```make clean
+make
+```
 
 **Step 2**
 
@@ -37,18 +40,20 @@ sudo service klipper stop
 If you already have a functioning CAN setup, and your [mcu toolhead] canbus_uuid is in your printer.cfg, then you can force Katapult to reboot into Katapult mode by running:
 
 ```bash
-python3 ~/katapult/scripts/flashtool.py -i can0 -u yourtoolheaduuid -r
+python3 ~/katapult/scripts/flashtool.py -i can0 -r -u yourtoolheaduuid
 ```
 
 ![image](https://github.com/Esoterical/voron_canbus/assets/124253477/eda51419-6ab4-49c5-9c33-a581b08d085c)
 
-If will probably say "Flash success" **THIS IS NOT ACTUALLY FLASHING ANYTHING, YOU NEED TO CONTINUE WITH THE STEPS BELOW**
+If will probably say "Flash success" 
+**THIS IS NOT ACTUALLY FLASHING ANYTHING, YOU NEED TO CONTINUE WITH THE STEPS BELOW**
 
 **Step 3**
 
 If you don't have the UUID (or something has gone wrong with the klipper firmware and your toolboard is hung) then you can also double-press the RESET button on your toolhead to force Katapult to reboot into Katapult mode.
 
 You can verify it is in the proper mode by running `python3 ~/katapult/scripts/flashtool.py -q`. If you see a "Detected UUID: xxxxxxxxx, Application: Katapult" device then it is good to go.
+```python3 ~/katapult/scripts/flashtool.py -q```
 
 ![image](https://github.com/Esoterical/voron_canbus/assets/124253477/ff9dcbb3-0456-4d87-8091-41d5d6050c02)
 
@@ -57,10 +62,11 @@ You can verify it is in the proper mode by running `python3 ~/katapult/scripts/f
 Then you can run the same command you used to initially flash Klipper:
 
 ```bash
-python3 ~/katapult/scripts/flashtool.py -i can0 -u yourtooolheaduuid -f ~/klipper/out/klipper.bin
+python3 ~/katapult/scripts/flashtool.py -i can0 -f ~/klipper/out/klipper.bin -u yourtooolheaduuid
 ```
 
 Once the flash has been completed you can run the `python3 ~/katapult/scripts/flashtool.py -i can0 -q` command again. This time you should see the same UUID but with "Application: Klipper" instead of "Application: Katapult"
+```python3 ~/katapult/scripts/flashtool.py -i can0 -q```
 
 ![image](https://github.com/Esoterical/voron_canbus/assets/124253477/1e01f858-71f3-45b4-a69f-1f704dce80d4)
 
@@ -68,3 +74,4 @@ Once the flash has been completed you can run the `python3 ~/katapult/scripts/fl
 **If** you can't connect to your tooolhead after these steps (assuming all the ouputs look similar in success to the screenshots) then there is a good chance your klipper.bin settings were incorrect. Go back to Step 1 and check *all* the settings in the `make menuconfig` screen then recompile with `make clean` and `make`, and then double-click the reset button on your toolhead to kick it back to katapult mode then go from Step 3.
 
 However, **if** the CAN query *does* return your UUID with "Application: Klipper" then start the Klipper service on the Pi again with `sudo service klipper start` and then do a firmware_restart and confirm that Klipper starts without errors.
+```sudo service klipper start```

--- a/toolhead_klipper_updating.md
+++ b/toolhead_klipper_updating.md
@@ -25,7 +25,8 @@ You can find screenshots of settings for common toolheads in the [Common Toolhea
 You want the Processor and Clock Reference to be set as per whatever board you are running. Set Communication interface to 'CAN bus' with the pins that are specific to your toolhead board. Also set the CAN bus speed to the same as the speed in your can0 file. In this guide it is set to 1000000.
 
 Once you have the firmware configured, hit Q to save and quit from the makemenu screen, then run a `make clean` to make sure there are no old files hanging around, then `make` to compile the firmware. It will save the firmware to ~/klipper/out/klipper.bin
-```make clean
+```bash
+make clean
 make
 ```
 
@@ -53,7 +54,9 @@ If will probably say "Flash success"
 If you don't have the UUID (or something has gone wrong with the klipper firmware and your toolboard is hung) then you can also double-press the RESET button on your toolhead to force Katapult to reboot into Katapult mode.
 
 You can verify it is in the proper mode by running `python3 ~/katapult/scripts/flashtool.py -q`. If you see a "Detected UUID: xxxxxxxxx, Application: Katapult" device then it is good to go.
-```python3 ~/katapult/scripts/flashtool.py -q```
+```bash
+python3 ~/katapult/scripts/flashtool.py -q
+```
 
 ![image](https://github.com/Esoterical/voron_canbus/assets/124253477/ff9dcbb3-0456-4d87-8091-41d5d6050c02)
 
@@ -66,7 +69,9 @@ python3 ~/katapult/scripts/flashtool.py -i can0 -f ~/klipper/out/klipper.bin -u 
 ```
 
 Once the flash has been completed you can run the `python3 ~/katapult/scripts/flashtool.py -i can0 -q` command again. This time you should see the same UUID but with "Application: Klipper" instead of "Application: Katapult"
-```python3 ~/katapult/scripts/flashtool.py -i can0 -q```
+```bash
+python3 ~/katapult/scripts/flashtool.py -i can0 -q
+```
 
 ![image](https://github.com/Esoterical/voron_canbus/assets/124253477/1e01f858-71f3-45b4-a69f-1f704dce80d4)
 
@@ -74,4 +79,6 @@ Once the flash has been completed you can run the `python3 ~/katapult/scripts/fl
 **If** you can't connect to your tooolhead after these steps (assuming all the ouputs look similar in success to the screenshots) then there is a good chance your klipper.bin settings were incorrect. Go back to Step 1 and check *all* the settings in the `make menuconfig` screen then recompile with `make clean` and `make`, and then double-click the reset button on your toolhead to kick it back to katapult mode then go from Step 3.
 
 However, **if** the CAN query *does* return your UUID with "Application: Klipper" then start the Klipper service on the Pi again with `sudo service klipper start` and then do a firmware_restart and confirm that Klipper starts without errors.
-```sudo service klipper start```
+```bash
+sudo service klipper start
+```


### PR DESCRIPTION
These are some quality-of-life changes to the instructions with the aim of making it easier to quickly execute all the required steps/commands. There are two themes:

1. Modified several of the instruction pages to make it easier to follow with new bash blocks with the commands mentioned in-line.
1. Modified some commands to move the uuid (or similar) fields to the end of the command so its easier to update with the required values after pasting into a terminal.

Hope the formatting/structure is ok.
Thanks