### PR TITLE
Mention potentially missing CAN adapter drivers

### DIFF
--- a/Dedicated_USB_Can_Device.md
+++ b/Dedicated_USB_Can_Device.md
@@ -35,7 +35,7 @@ You see a can0 interface, the "qlen" will be 128, and the bitrate will be 100000
 >  <img src="https://github.com/Esoterical/voron_canbus/assets/124253477/36065239-009c-4195-8e13-a43959acac7b" />
 ></p>
 >
->If the `ip -s -d link show can0` command returns an error then go back to ths top of this page and check that your USB CAN adapter is properly showing up to an `lsusb` command.
+>If the `ip -s -d link show can0` command returns an error then go back to ths top of this page and check that your USB CAN adapter is properly showing up to an `lsusb` command. Alternatively, take a look at other identified issues in [Troubleshooting > No can0 Interface](./troubleshooting/no_can0.md).
 >
 >If the can0 network shows up, but the qlen *isn't* 128 or the bitrate *isn't* 1000000 then go back to [Getting_Started](./Getting_Started.md) and check the can0 file settigns in both the ifupdown section and the netplan section.
 

--- a/can_adapter/BigTreeTech U2C v2.1/README.md
+++ b/can_adapter/BigTreeTech U2C v2.1/README.md
@@ -61,3 +61,16 @@ sudo dfu-util -D ~/G0B1_U2C_V2.bin -a 0 -s 0x08000000:leave
 You may see an "error during download get-status" down the bottom. You can ignore that as long as everything else is successful.
 
 Once flashed, unplug the U2C from the Pi then plug it back in. Run an `ifconfig` and you should see a "can0" interface (assuming you have already set the /etc/network/interfaces.d/can0 file). If so, then congratulations your U2C is succesfully flashed with the fixed firmware.
+
+# Missing drivers
+
+Check whether appropriate Linux driver for the adapter is available:
+```bash
+lsmod | grep can
+```
+
+Expected output should contain `gs_usb` (which is a driver for "Geschwister Schneider CAN adapter" based adapters).
+
+If the output does not mention `gs_usb` anywhere, it is likely that you are missing an appropriate driver. This may happen when using less common SBCs and their respective OS image has that module disabled (eg. certain builds of Armbian might have this module disabled during build-time).
+
+With the required driver missing, you may need to use a different OS image, recompile the image, contact the OS image maintainers to include that module, or compile the module stand-alone and then install it.

--- a/troubleshooting/no_can0.md
+++ b/troubleshooting/no_can0.md
@@ -15,7 +15,7 @@ First thing to check is your `/etc/systemd/network/25-can.network` file. Make su
 
 ### Seperate USB-CAN adapter (U2C/UTOC/etc.)
 
-If you are using a seprate USB to CAN adapter (U2C/UTOC/etc.) then double check that the USB cable connecting the devices is plugged in and not loose. If you _never_ get a response to a query (ie. the can0 interface has never shown at all) then you may have a dodgy USB cable. I have personally seen a handful of usb-c cables that don't actually have the data pins hooked up (they are power only). If the adapter doesn't show to an `lsusb` then your cable is probably dodgy.
+If you are using a separate USB to CAN adapter (U2C/UTOC/etc.) then double check that the USB cable connecting the devices is plugged in and not loose. If you _never_ get a response to a query (ie. the can0 interface has never shown at all) then you may have a dodgy USB cable. I have personally seen a handful of usb-c cables that don't actually have the data pins hooked up (they are power only). If the adapter doesn't show to an `lsusb` then your cable is probably dodgy.
 
 If it shows up to an `lsusb` but an `ip link show can0` shows "Device can0 does not exist" then you might have a bad firmware, something wrong on your device, or problems with your CAN adapter drivers.
 

--- a/troubleshooting/no_can0.md
+++ b/troubleshooting/no_can0.md
@@ -17,7 +17,11 @@ First thing to check is your `/etc/systemd/network/25-can.network` file. Make su
 
 If you are using a seprate USB to CAN adapter (U2C/UTOC/etc.) then double check that the USB cable connecting the devices is plugged in and not loose. If you _never_ get a response to a query (ie. the can0 interface has never shown at all) then you may have a dodgy USB cable. I have personally seen a handful of usb-c cables that don't actually have the data pins hooked up (they are power only). If the adapter doesn't show to an `lsusb` then your cable is probably dodgy.
 
-If it shows up to an `lsusb` but an `ip link show can0` shows "Device can0 does not exist" then you might have a bad firmware or something on your device. Reflash it with the appropriate firmware either from a manufacturer github repository or other source (like candlelight). If there are instructions back on the voron_canbus/can_adapter folder then follow those.
+If it shows up to an `lsusb` but an `ip link show can0` shows "Device can0 does not exist" then you might have a bad firmware, something wrong on your device, or problems with your CAN adapter drivers.
+
+When you suspect problems with the device itself, reflash it with the appropriate firmware either from a manufacturer github repository or other source (like candlelight). If there are instructions back on the voron_canbus/can_adapter folder then follow those.
+
+When you suspect problems with the drivers, it is worth checking whether appropriate driver module is installed and enabled in the OS. You can try looking for CAN-related modules: `lsmod | grep can`. For example, "Geschwister Schneider CAN adapter" based devices require `gs_usb` driver. If the identified required driver is missing, you may need to use a different OS image, recompile the image (eg. when using Armbian and the maintainers decided to disable appropriate module for your board), or compile the module stand-alone and then install it.
 
 ### USB-CAN-Bridge mode mainboard
 


### PR DESCRIPTION
Recently after updating my OS image (my Klipper instance is running on Orange Pi Zero 3 and Armbian) I've stumbled upon a problem of CAN devices being completely gone after system reboot. After some digging, I've discovered that the maintainers of my SBC did some cleanups in the OS build configuration, and removed inclusion of CAN adapters' drivers, which in turn rendered CAN devices inoperable (even though the Adapter, BTT U2C, was visible on the `lsusb` list as normal).

None of the instructions here mentioned this issue (I suspect using Armbian is not that common among Klipper users), so I've added some simplistic instructions allowing users to try to verify whether that's their problem. I've also included potential ways to fix the issue, however in most cases that involves recompiling the OS image, which is definitely out of scope of this documentation. Still, a mention might be useful for more advanced users.