### PR TITLE
Fysetc Hexa distro fusion board

### DIFF
--- a/mainboard_flashing/common_hardware/Fysetc Hexa Distro Fusion/README.md
+++ b/mainboard_flashing/common_hardware/Fysetc Hexa Distro Fusion/README.md
@@ -7,11 +7,19 @@ grand_parent: Mainboard Flashing
 
 # 120 ohm Termination Resistor
 
-The board has a 120ohm termination resistor by default, you need to cut the trace at JP1 to remove it from the circuit.
+The board has a 120ohm termination resistor by default, you need to cut the trace at JP1 if you want to remove it from the circuit.
+
+<img width="78" height="83" alt="image" src="https://github.com/user-attachments/assets/b21462f0-a5b9-4800-aee5-da9ea953b0f4" />
+
+<img width="454" height="357" alt="image" src="https://github.com/user-attachments/assets/260831df-0999-4e2d-b1e4-89f90ad0f7e6" />
+
 
 # CAN Port
 
 There are 6 CAN JST-XH ports
+
+<img width="427" height="151" alt="image" src="https://github.com/user-attachments/assets/85a18815-4395-431b-b72e-f2d4290f9f97" />
+
 
 
 # DFU Mode
@@ -21,8 +29,13 @@ Hold down BOOT and tap RESET, then let go of BOOT.
 
 # Katapult Config
 
+<img width="688" height="229" alt="image" src="https://github.com/user-attachments/assets/4d57d20a-15c9-4f5b-90ab-5d67a55266ec" />
+
+
 
 # Klipper USB-CAN-Bridge Config
+
+<img width="646" height="208" alt="image" src="https://github.com/user-attachments/assets/ddd7a358-42cb-4056-be9b-ca886ec8ff99" />
 
 
 

--- a/mainboard_flashing/common_hardware/Fysetc Hexa Distro Fusion/README.md
+++ b/mainboard_flashing/common_hardware/Fysetc Hexa Distro Fusion/README.md
@@ -1,0 +1,29 @@
+---
+layout: default 
+title: Fysetc Hexa Distro Fusion
+parent: Common Mainboard Hardware
+grand_parent: Mainboard Flashing
+---
+
+# 120 ohm Termination Resistor
+
+The board has a 120ohm termination resistor by default, you need to cut the trace at JP1 to remove it from the circuit.
+
+# CAN Port
+
+There are 6 CAN JST-XH ports
+
+
+# DFU Mode
+
+Hold down BOOT and tap RESET, then let go of BOOT.
+
+
+# Katapult Config
+
+
+# Klipper USB-CAN-Bridge Config
+
+
+
+


### PR DESCRIPTION
The board is mostly used for toolchangers but flashes in exactly the same way as a mainboard, I followed the mainboard USB CAN adapter instructions and it worked straight away.

(https://wiki.fysetc.com/docs/hexa_distro_fusion)