### PR TITLE
One more TimerTooClose story for troubleshooting

### DIFF
--- a/troubleshooting/timer_too_close.md
+++ b/troubleshooting/timer_too_close.md
@@ -50,4 +50,6 @@ They also observed this problem was more likely on short distances (IE smaller p
 
 `TTC when Exclude Object was used on a large/complex model. Possibly the host overloaded trying to skip the bazillion lines of gcode`
 
+`TTC mentioning the CAN toolhead board. Ended up being broken CAN wiring. If you are using a BigTreeTech EBB board, do not put the supplied cable inside dragchains, it is not rated for that. Discovered using a multimeter by checking the resistance between CAN-L and CAN-H at the base with the power off and slowly moving the carriage by hand, the reading changed between 60ohms (good connection) and 120ohms (meaning the toolhead is disconnected).`
+
 [Return to Troubleshooting](../troubleshooting.md)


### PR DESCRIPTION
It took weeks to figure this one out, so I hope this can help others. Feel free to rephrase as needed.

What made me find it was ending up with a reliable repro (as in, my cable eventually was broken enough to prevent me from homing), prior to that the printer was simply "unreliable" and would randomly lose communication with the toolhead, sometimes mid-print, sometimes idling... sometimes it was fine for days.